### PR TITLE
Show search results by reversing colours, and optimisation status by changing key

### DIFF
--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -221,12 +221,14 @@ class FrameNode {
   }
 
   toJSON () {
+    // Used for search matching. '(inlinable)' added at start without spaces based on d3-fg search string parsing
+    /* istanbul ignore next: inlinability is not always consistent between runs of the same test */
+    const name = this.isInlinable ? '(inlinable)' + this.name : this.name
+
     return {
       id: this.id,
 
-      // Used for search matching. '(inlinable)' added at start without spaces based on d3-fg search string parsing
-      /* istanbul ignore next: inlinability is not always consistent between runs of the same test */
-      name: this.isInlinable ? '(inlinable)' + this.name : this.name,
+      name,
 
       fileName: this.fileName,
       functionName: this.functionName,

--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -225,6 +225,7 @@ class FrameNode {
       id: this.id,
 
       // Used for search matching. '(inlinable)' added at start without spaces based on d3-fg search string parsing
+      /* istanbul ignore next: inlinability is not always consistent between runs of the same test */
       name: this.isInlinable ? '(inlinable)' + this.name : this.name,
 
       fileName: this.fileName,

--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -223,7 +223,10 @@ class FrameNode {
   toJSON () {
     return {
       id: this.id,
-      name: this.name,
+
+      // Used for search matching. '(inlinable)' added at start without spaces based on d3-fg search string parsing
+      name: this.isInlinable ? '(inlinable)' + this.name : this.name,
+
       fileName: this.fileName,
       functionName: this.functionName,
       lineNumber: this.lineNumber,

--- a/visualizer/flame-graph-frame.js
+++ b/visualizer/flame-graph-frame.js
@@ -7,7 +7,6 @@ function getFrameRenderer (bindTo) {
 function renderStackFrame (globals, locals, rect) {
   const {
     colorHash,
-    frameColors,
     STATE_IDLE
   } = globals
   const {
@@ -46,9 +45,14 @@ function renderStackFrame (globals, locals, rect) {
     height: roundedHeight
   }
 
+  const categoryColor = this.ui.exposedCSS[nodeData.category]
+
+  // Reverse text and background for any current search matches
+  const bkgColor = this.ui.exposedCSS[nodeData.highlight ? nodeData.category : 'opposite-contrast']
+
   // For really tiny frames, draw a 1px thick pixel-aligned 'matchstick' line
   if (width <= 1.5) {
-    renderAsLine(context, rect, frameColors.fill, this.ui.exposedCSS[nodeData.category], colorHash(nodeData))
+    renderAsLine(context, rect, bkgColor, categoryColor, nodeData.highlight)
     return
   }
 
@@ -57,8 +61,8 @@ function renderStackFrame (globals, locals, rect) {
 
   // Give rect an initial solid stroke using fill color so things behind
   // e.g. heat bar don't show through
-  context.fillStyle = frameColors.fill
-  context.strokeStyle = frameColors.fill
+  context.fillStyle = bkgColor
+  context.strokeStyle = bkgColor
 
   context.beginPath()
   context.rect(left, top, alignDown(width) - 1, alignDown(height))
@@ -92,7 +96,7 @@ function renderHeatBar (context, nodeData, colorHash, rect) {
   context.stroke()
 }
 
-function renderAsLine (context, rect, fillCol, areaCol) {
+function renderAsLine (context, rect, fillCol, areaCol, isHighlighted) {
   const {
     x,
     y,
@@ -108,7 +112,9 @@ function renderAsLine (context, rect, fillCol, areaCol) {
 
   // Add code area tint to the appropriate part of the line
   context.save()
-  context.globalAlpha = 0.2
+
+  // Bolden any tiny active search matches
+  context.globalAlpha = isHighlighted ? 0.9 : 0.2
   context.strokeStyle = areaCol
   context.beginPath()
   context.moveTo(x, y)

--- a/visualizer/flame-graph-frame.js
+++ b/visualizer/flame-graph-frame.js
@@ -45,24 +45,24 @@ function renderStackFrame (globals, locals, rect) {
     height: roundedHeight
   }
 
-  const categoryColor = this.ui.exposedCSS[nodeData.category]
-
-  // Reverse text and background for any current search matches
-  const bkgColor = this.ui.exposedCSS[nodeData.highlight ? nodeData.category : 'opposite-contrast']
-
   // For really tiny frames, draw a 1px thick pixel-aligned 'matchstick' line
   if (width <= 1.5) {
-    renderAsLine(context, rect, bkgColor, categoryColor, nodeData.highlight)
+    const backgroundColor = this.ui.getFrameColor(nodeData, 'background', false)
+    const foregroundColor = this.ui.getFrameColor(nodeData, 'foreground', false)
+    renderAsLine(context, rect, backgroundColor, foregroundColor, nodeData.highlight)
     return
   }
 
   // Don't redraw heat over previous paint on hover events, and don't draw for root node
   if (state === STATE_IDLE && nodeData.id !== 0) renderHeatBar(context, nodeData, colorHash, alignedRect)
 
+  const backgroundColor = this.ui.getFrameColor(nodeData, 'background')
+  const foregroundColor = this.ui.getFrameColor(nodeData, 'foreground')
+
   // Give rect an initial solid stroke using fill color so things behind
   // e.g. heat bar don't show through
-  context.fillStyle = bkgColor
-  context.strokeStyle = bkgColor
+  context.fillStyle = backgroundColor
+  context.strokeStyle = backgroundColor
 
   context.beginPath()
   context.rect(left, top, alignDown(width) - 1, alignDown(height))
@@ -72,7 +72,7 @@ function renderStackFrame (globals, locals, rect) {
   // Add a light stroke to left, bottom and right indicating code area
   context.save()
   context.globalAlpha = 0.2
-  context.strokeStyle = this.ui.exposedCSS[nodeData.category]
+  context.strokeStyle = foregroundColor
   context.beginPath()
   context.moveTo(left, top)
   context.lineTo(left, bottom)
@@ -96,7 +96,7 @@ function renderHeatBar (context, nodeData, colorHash, rect) {
   context.stroke()
 }
 
-function renderAsLine (context, rect, fillCol, areaCol, isHighlighted) {
+function renderAsLine (context, rect, backgroundColor, foregroundColor, isHighlighted) {
   const {
     x,
     y,
@@ -104,7 +104,7 @@ function renderAsLine (context, rect, fillCol, areaCol, isHighlighted) {
   } = rect
 
   // Black solid background line, including black heat area
-  context.strokeStyle = fillCol
+  context.strokeStyle = backgroundColor
   context.beginPath()
   context.moveTo(x, y - getHeatHeight(height))
   context.lineTo(x, y + height)
@@ -115,7 +115,7 @@ function renderAsLine (context, rect, fillCol, areaCol, isHighlighted) {
 
   // Bolden any tiny active search matches
   context.globalAlpha = isHighlighted ? 0.9 : 0.2
-  context.strokeStyle = areaCol
+  context.strokeStyle = foregroundColor
   context.beginPath()
   context.moveTo(x, y)
   context.lineTo(x, y + height)

--- a/visualizer/flame-graph-label.js
+++ b/visualizer/flame-graph-label.js
@@ -26,7 +26,7 @@ function renderLabel (frameHeight, options) {
   context.font = `${fontSize}px ${this.labelFont}`
 
   // Reverse text and background for any current search matches
-  context.fillStyle = this.ui.exposedCSS[nodeData.highlight ? 'opposite-contrast' : nodeData.category]
+  context.fillStyle = this.ui.getFrameColor(nodeData, 'foreground')
 
   // Use root node as a zoom out button, blank when not zoomed in
   if (nodeData.id === 0) {
@@ -42,6 +42,12 @@ function renderLabel (frameHeight, options) {
   // Must have implemented the bars for code area changes first
   let fileName = nodeData.fileName
   let functionName = nodeData.functionName
+
+  if (nodeData.isInlinable) functionName += ' (inlinable)'
+
+  if (this.ui.dataTree.showOptimizationStatus && (nodeData.isOptimised || nodeData.isOptimisable)) {
+    functionName += ` (${nodeData.isOptimised ? 'is optimized' : 'optimizable'})`
+  }
 
   if (fileName === null) {
     if (nodeData.type === 'v8') fileName = 'Compiled V8 C++'

--- a/visualizer/flame-graph-label.js
+++ b/visualizer/flame-graph-label.js
@@ -24,7 +24,9 @@ function renderLabel (frameHeight, options) {
   const yBottom = y + frameHeight - btmOffset
 
   context.font = `${fontSize}px ${this.labelFont}`
-  context.fillStyle = this.ui.exposedCSS[nodeData.category]
+
+  // Reverse text and background for any current search matches
+  context.fillStyle = this.ui.exposedCSS[nodeData.highlight ? 'opposite-contrast' : nodeData.category]
 
   // Use root node as a zoom out button, blank when not zoomed in
   if (nodeData.id === 0) {

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -328,21 +328,16 @@ class FlameGraph extends HtmlContent {
       this.flameGraph.width(this.width)
     }
 
+    let redrawGraph = false
+
     if (this.renderedTree !== dataTree.activeTree()) {
       this.renderedTree = dataTree.activeTree()
-      this.flameGraph.renderTree(this.renderedTree)
+      redrawGraph = true
     }
 
-    // Highlight optimized frames in a very aggressive yellow…
-    // TODO nicer styling, prob needs a d3-fg change to add some indicator element
-    // or we could pick a more subtle background color.
-    if (this.showOptimizationStatus !== this.ui.dataTree.showOptimizationStatus) {
-      this.showOptimizationStatus = this.ui.dataTree.showOptimizationStatus
-      if (this.showOptimizationStatus) {
-        this.flameGraph.search(/^\*/, 'yellow')
-      } else {
-        this.flameGraph.clear('yellow')
-      }
+    if (this.showOptimizationStatus !== dataTree.showOptimizationStatus) {
+      this.showOptimizationStatus = dataTree.showOptimizationStatus
+      redrawGraph = true
     }
 
     const { toHide, toShow } = this.ui.changedExclusions
@@ -351,16 +346,20 @@ class FlameGraph extends HtmlContent {
     if (toHide.size > 0) {
       toHide.forEach((name) => {
         this.flameGraph.typeHide(name)
+        redrawGraph = false
       })
       isChanged = true
     }
     if (toShow.size > 0) {
       toShow.forEach((name) => {
         this.flameGraph.typeShow(name)
+        redrawGraph = false
       })
       isChanged = true
     }
-    if (isChanged) this.updateMarkerBoxes()
+
+    if (isChanged || redrawGraph) this.updateMarkerBoxes()
+    if (redrawGraph) this.flameGraph.renderTree(this.renderedTree)
   }
 }
 

--- a/visualizer/info-box.js
+++ b/visualizer/info-box.js
@@ -44,6 +44,11 @@ class InfoBox extends HtmlContent {
     const categoryLabel = this.ui.getLabelFromKey(node.category, true)
     this.areaText = `In ${categoryLabel} (${typeLabel})`
 
+    if (node.isInlinable) this.areaText += '. Inlinable'
+    if (node.isOptimisable) this.areaText += '. Optimizable'
+    if (node.isOptimised) this.areaText += '. Is optimized'
+    this.areaText += '.'
+
     this.draw()
   }
 

--- a/visualizer/key.js
+++ b/visualizer/key.js
@@ -6,7 +6,9 @@ class Key extends HtmlContent {
   constructor (parentContent, contentProperties = {}) {
     super(parentContent, contentProperties)
 
-    this.appName = 'app'
+    this.app = 'Profiled app'
+    this.deps = 'Dependencies'
+    this.core = 'Node Core'
   }
 
   initializeElements () {
@@ -15,15 +17,15 @@ class Key extends HtmlContent {
     this.d3Title = this.d3Element.append('div')
       .classed('key-title', true)
 
-    this.d3AppName = this.d3Element.append('div')
-      .classed('key key-app', true)
-      .text(this.appName)
-    this.d3Element.append('div')
-      .classed('key key-deps', true)
-      .text('dependencies')
-    this.d3Element.append('div')
-      .classed('key key-core', true)
-      .text('node core')
+    this.d3Key1 = this.d3Element.append('div')
+      .classed('key', true)
+      .text(this.app)
+    this.d3Key2 = this.d3Element.append('div')
+      .classed('key', true)
+      .text(this.deps)
+    this.d3Key3 = this.d3Element.append('div')
+      .classed('key', true)
+      .text(this.core)
 
     this.ui.on('setData', () => {
       this.setData()
@@ -42,7 +44,27 @@ class Key extends HtmlContent {
   draw () {
     super.draw()
 
-    this.d3AppName.text(this.appName)
+    const showOpt = this.ui.dataTree.showOptimizationStatus
+
+    this.d3Key1
+      .text(showOpt ? 'Optimizable' : this.appName)
+      .style('color', this.ui.getFrameColor({
+        category: 'app',
+        isOptimisable: true
+      }, 'foreground', false))
+
+    this.d3Key2
+      .text(showOpt ? 'Is optimized' : this.deps)
+      .style('color', this.ui.getFrameColor({
+        category: 'deps',
+        isOptimised: true
+      }, 'foreground', false))
+
+    this.d3Key3
+      .text(showOpt ? 'Not JavaScript' : this.core)
+      .style('color', this.ui.getFrameColor({
+        category: 'all-core'
+      }, 'foreground', false))
 
     const titleHTML = `Call stacks in <em>${this.appName}</em>, grouped, by time spent on stack`
     this.d3Title.html(titleHTML)

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -46,6 +46,7 @@ html {
   --footer-color: rgba(255, 255, 255, 0.9);
 
   --cyan: rgb(63, 125, 198);
+  --grey-blue: rgb(76, 92, 138);
   --primary-grey: rgb(121, 122, 124);
   --grey-highlight-color-val: 191, 192, 194;
   --grey-highlight: rgb(var(--grey-highlight-color-val));

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -340,8 +340,8 @@ class Ui extends events.EventEmitter {
   }
 
   /**
-  * Initialization and draw
-  **/
+   * Initialization and draw
+   **/
 
   setExposedCSS () {
     // TODO: When light / dark theme switch implemented, call this after each switch, before redraw
@@ -350,7 +350,25 @@ class Ui extends events.EventEmitter {
       app: computedStyle.getPropertyValue('--area-color-app').trim(),
       deps: computedStyle.getPropertyValue('--area-color-deps').trim(),
       'all-core': computedStyle.getPropertyValue('--area-color-core').trim(),
-      'opposite-contrast': computedStyle.getPropertyValue('--opposite-contrast').trim()
+
+      'opposite-contrast': computedStyle.getPropertyValue('--opposite-contrast').trim(),
+      'max-contrast': computedStyle.getPropertyValue('--max-contrast').trim(),
+      'grey-blue': computedStyle.getPropertyValue('--grey-blue').trim(),
+      'primary-grey': computedStyle.getPropertyValue('--primary-grey').trim()
+    }
+  }
+
+  getFrameColor (nodeData, role, reverse = nodeData.highlight) {
+    if ((role === 'background' && !reverse) || (role === 'foreground' && reverse)) {
+      return this.exposedCSS['opposite-contrast']
+    }
+
+    if (this.dataTree.showOptimizationStatus) {
+      if (nodeData.isOptimisable) return this.exposedCSS['max-contrast']
+      if (nodeData.isOptimised) return this.exposedCSS['primary-grey']
+      return this.exposedCSS['grey-blue']
+    } else {
+      return this.exposedCSS[nodeData.category]
     }
   }
 

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -349,7 +349,8 @@ class Ui extends events.EventEmitter {
     this.exposedCSS = {
       app: computedStyle.getPropertyValue('--area-color-app').trim(),
       deps: computedStyle.getPropertyValue('--area-color-deps').trim(),
-      'all-core': computedStyle.getPropertyValue('--area-color-core').trim()
+      'all-core': computedStyle.getPropertyValue('--area-color-core').trim(),
+      'opposite-contrast': computedStyle.getPropertyValue('--opposite-contrast').trim()
     }
   }
 


### PR DESCRIPTION
Search results stopped highlighting in https://github.com/nearform/node-clinic-flame/commit/1aabfe74f41e454299ec71b8df9b105feb662e54 - previously, a default from d3-fg was relied upon for styling search results.

The first commit fixes that and applies a stable search style, highlighting matches by:

 - On normal frames, reversing the colours, giving the background a bright white, blue or grey so that search matches stand out and can still be easily identified as app, deps or core
 - On tiny frames, which were previously just a line tinted in the colour of app, deps or core, the tint is strengthened, resulting in the same visual effect - regardless of size, it stands out in that colour.

![image](https://user-images.githubusercontent.com/29628323/47967646-94525380-e057-11e8-80e2-dc73a94be274.png)

However, `showOptimisationStatus` previously worked using search, which gets broken by this change. That was always a bit of a temporary quick fix for showing optimisation status, so the second commit fleshes it out into a more rounded feature:

- When ticked, writes (optimized) or (is optimizable) as appropriate on the flamegraph
- When ticked, replaces the app, deps, core colouring with optimizable (most highlighted, because it's most actionable), is optimized (grey, common state) and "Not JavaScript" for non-JS frames where neither flag is present (blue grey, less bright than the deps cyan because this is something that is worth distinguishing, but isn't worth drawing much attention to)
- When ticked, updates the key appropriately
- Always adds information about optimization status and inlined status to the info bar, regardless of whether the box is ticked (because it's unobtrusive there and potentially interesting information whenever a user is inspecting one frame)
- Always writes '(inlinable)' on to the frame graph alongside the function name when true

![image](https://user-images.githubusercontent.com/29628323/47968814-e9499600-e066-11e8-8898-324fe83b54d7.png)

The third commit ensures that when doing a search for 'inlinable', frames that are inlinable do get highlighted.

![image](https://user-images.githubusercontent.com/29628323/47968838-2dd53180-e067-11e8-9bb0-d466ab99e89d.png)
