### PR TITLE
Fix info bar quirky cases

### DIFF
--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -290,7 +290,7 @@ class FlameGraph extends HtmlContent {
 
     d3Div
       .style('width', rect.width + 'px')
-      .style('height', height + 'px')
+      .style('height', (height < 0 ? 0 : height) + 'px')
       .style('transform', translate)
   }
 

--- a/visualizer/info-box.css
+++ b/visualizer/info-box.css
@@ -34,6 +34,5 @@
   flex-grow: 1;
   overflow: hidden;
   word-break: break-word;
-  flex-basis: 55%; /* sort of magic number I know... */
   flex-shrink: 0;
 }

--- a/visualizer/info-box.css
+++ b/visualizer/info-box.css
@@ -7,7 +7,7 @@
   margin: 0;
   overflow: hidden;
   padding: 2px 8px;
-  white-space: normal;
+  white-space: pre-wrap;
 }
 
 #info-box .frame-info:hover {
@@ -20,19 +20,42 @@
   word-break: break-word;
 }
 
-#info-box .frame-info em {
-  font-style: italic;
+#info-box span.frame-info-item {
+  flex-grow: 1;
+}
+
+#info-box .frame-info .frame-area {
   color: var(--primary-grey);
   word-break: break-word;
+  text-align: right;
 }
 
 #info-box .frame-info-item {
-  margin: 0 8px;
+  padding: 0 8px;
 }
 
 #info-box .frame-info .frame-path {
-  flex-grow: 1;
   overflow: hidden;
   word-break: break-word;
   flex-shrink: 0;
+}
+
+/* Share space, with the file path always starting in a consistent position, */
+/* unless function name is unusually long, in which case it shrinks to fit */
+#info-box .frame-function {
+  flex-grow: 0;
+}
+
+#info-box .frame-path,
+#info-box .frame-area {
+  flex-grow: 1;
+}
+
+#info-box .frame-function,
+#info-box .frame-area {
+  min-width: 16.67%;
+}
+
+#info-box .frame-path {
+  max-width: 66.67%;
 }

--- a/visualizer/info-box.js
+++ b/visualizer/info-box.js
@@ -20,13 +20,15 @@ class InfoBox extends HtmlContent {
 
     this.d3FrameFunction = this.d3FrameInfo.append('strong')
       .classed('frame-info-item', true)
+      .classed('frame-function', true)
 
     this.d3FramePath = this.d3FrameInfo.append('span')
       .classed('frame-info-item', true)
       .classed('frame-path', true)
 
-    this.d3FrameArea = this.d3FrameInfo.append('em')
+    this.d3FrameArea = this.d3FrameInfo.append('span')
       .classed('frame-info-item', true)
+      .classed('frame-area', true)
   }
 
   contentFromNode (node) {


### PR DESCRIPTION
Fixes a few cases where the display of the info bar looks wrong:

1. Removes the `flex-basis` that allocates more space to the file path than it necessarily needs:

Before:

![image](https://user-images.githubusercontent.com/29628323/47969777-77784900-e074-11e8-84e9-0bb62927d192.png)

After:

![image](https://user-images.githubusercontent.com/29628323/47969745-32ecad80-e074-11e8-8b98-7ac1ba115532.png)

2. Replaces it with another way of sharing the text that gives file paths a consistent starting position except where an unusually long function name needs more space:

![image](https://user-images.githubusercontent.com/29628323/47969832-008f8000-e075-11e8-97d4-3c7fac203097.png)

![image](https://user-images.githubusercontent.com/29628323/47969829-ed7cb000-e074-11e8-8410-605b9fbe518d.png)

![image](https://user-images.githubusercontent.com/29628323/47969848-4ea48380-e075-11e8-9d7c-5ce690039651.png)

![image](https://user-images.githubusercontent.com/29628323/47969861-7a276e00-e075-11e8-978e-9043b71a2b38.png)


3. Fixes a small bug where if a selected frame is above the current scroll position, the dotted line is assigned an invalid negative height and therefore keeps whatever height it had before.

Before: 

![image](https://user-images.githubusercontent.com/29628323/47969878-b4910b00-e075-11e8-98d1-99b8c270fd87.png)


After:

![image](https://user-images.githubusercontent.com/29628323/47969870-97f4d300-e075-11e8-81ea-663e614c1528.png)

