### PR TITLE
Fix stack bar undefined property access when there are few frames

### DIFF
--- a/visualizer/stack-bar.js
+++ b/visualizer/stack-bar.js
@@ -76,7 +76,11 @@ class StackBar extends HtmlContent {
     }
 
     if (!found) {
-      isInRemaining = frames[frames.length - 1].remaining.some((smallFrame) => smallFrame.id === node.id)
+      const lastFrame = frames[frames.length - 1]
+      // This may not be an aggregate `remaining` frame if all frames fit on the stack bar,
+      // which can happen on small profiles or with aggressive filters.
+      isInRemaining = Array.isArray(lastFrame.remaining) &&
+        lastFrame.remaining.some((smallFrame) => smallFrame.id === node.id)
     }
 
     return found || isInRemaining ? `${left * totalWidth + margin}px` : '-20px'


### PR DESCRIPTION
When all visible frames fit on the stack bar, there is no frame with a
`.remaining` property.

This fixes an issue where hovering the stack bar after toggling most
things off in the options menu would spew errors to the console.