### PR TITLE
Prevent duplicate `draw()` call in StackBar

### DIFF
--- a/visualizer/stack-bar.js
+++ b/visualizer/stack-bar.js
@@ -16,10 +16,6 @@ class StackBar extends HtmlContent {
     this.ui.on('selectNode', node => {
       this.pointToNode(node)
     })
-
-    this.ui.on('updateExclusions', node => {
-      this.draw()
-    })
   }
 
   initializeElements () {


### PR DESCRIPTION
The places that call `updateExclusions()` also already call `ui.draw()`,
in order to update the FlameGraph. That `.draw()` call also calls the
StackBar's `.draw()` method, so we don't need to do it in the
'updateExclusions' handler.

The StackBar is kinda expensive to update (can take about 30ms for a
single `.draw()` call) so it would be good to make it faster in the
future, but this will already save 50% so it's a good start :)