### PR TITLE
Open Node Core links in the browser

### DIFF
--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -106,11 +106,11 @@ class FrameNode {
     }
 
     // Some core types have files that can be linked to in the appropriate Node build
-    const nodeVersion = systemInfo.nodeVersions.node
-
     if (this.type === 'core') {
+      const nodeVersion = systemInfo.nodeVersions.node
       return `https://github.com/nodejs/node/blob/v${nodeVersion}/lib/${this.fileName}#L${this.lineNumber}`
     }
+
     // TODO: add more cases like this
   }
 

--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -104,15 +104,14 @@ class FrameNode {
     if (this.category === 'app' || this.category === 'deps') {
       return this.fileName
     }
-    // Some core types have files that can be linked to in the appropriate Node build
-    if (this.category === 'all-core') {
-      const nodeVersion = systemInfo.nodeVersions.node
 
-      if (this.type === 'core') {
-        return `https://github.com/nodejs/node/blob/v${nodeVersion}/lib/${this.fileName}#L${this.lineNumber}`
-      }
-      // TODO: add more cases like this
+    // Some core types have files that can be linked to in the appropriate Node build
+    const nodeVersion = systemInfo.nodeVersions.node
+
+    if (this.type === 'core') {
+      return `https://github.com/nodejs/node/blob/v${nodeVersion}/lib/${this.fileName}#L${this.lineNumber}`
     }
+    // TODO: add more cases like this
   }
 
   getCoreType (name, systemInfo) {

--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -104,15 +104,15 @@ class FrameNode {
     if (this.category === 'app' || this.category === 'deps') {
       return this.fileName
     }
-    /** TODO: this is an example, add more like this with tests
     // Some core types have files that can be linked to in the appropriate Node build
     if (this.category === 'all-core') {
       const nodeVersion = systemInfo.nodeVersions.node
 
-      if (this.type === 'core') return `https://github.com/nodejs/node/blob/v${nodeVersion}/lib/${this.fileName}#L${this.lineNumber}`
+      if (this.type === 'core') {
+        return `https://github.com/nodejs/node/blob/v${nodeVersion}/lib/${this.fileName}#L${this.lineNumber}`
+      }
       // TODO: add more cases like this
     }
-    */
   }
 
   getCoreType (name, systemInfo) {

--- a/test/analysis-categorise.test.js
+++ b/test/analysis-categorise.test.js
@@ -7,12 +7,14 @@ const {
 
 const linux = {
   mainDirectory: '/root',
-  pathSeparator: '/'
+  pathSeparator: '/',
+  nodeVersions: { node: '8.13.0' }
 }
 
 const windows = {
   mainDirectory: 'C:\\Documents\\Contains spaces',
-  pathSeparator: '\\'
+  pathSeparator: '\\',
+  nodeVersions: { node: '8.13.0' }
 }
 
 function byProps (properties, sysinfo) {

--- a/test/analysis-target.test.js
+++ b/test/analysis-target.test.js
@@ -1,0 +1,38 @@
+const test = require('tap').test
+const FrameNode = require('../analysis/frame-node.js')
+
+test('analysis - copy/paste targets', (t) => {
+  const systemInfo = {
+    pathSeparator: '/',
+    mainDirectory: '/home/clinic/code/app',
+    nodeVersions: { node: '10.11.0' }
+  }
+
+  const appNode = new FrameNode({
+    name: 'start /home/clinic/code/app/index.js:20:1'
+  })
+  appNode.categorise(systemInfo)
+  appNode.anonymise(systemInfo)
+  t.equal(appNode.getTarget(systemInfo), './index.js')
+
+  const parentDirNode = new FrameNode({
+    name: '(anonymous) /home/clinic/code/browserify/index.js:808:29'
+  })
+  parentDirNode.categorise(systemInfo)
+  parentDirNode.anonymise(systemInfo)
+  t.equal(parentDirNode.getTarget(systemInfo), '../browserify/index.js')
+
+  const coreFunctionNode = new FrameNode({
+    name: 'coreFunction util.js:15:7'
+  })
+  coreFunctionNode.categorise(systemInfo)
+  t.equal(coreFunctionNode.getTarget(systemInfo), 'https://github.com/nodejs/node/blob/v10.11.0/lib/util.js#L15')
+
+  const internalFunctionNode = new FrameNode({
+    name: 'deprecate internal/util.js:15:1'
+  })
+  internalFunctionNode.categorise(systemInfo)
+  t.equal(internalFunctionNode.getTarget(systemInfo), 'https://github.com/nodejs/node/blob/v10.11.0/lib/internal/util.js#L15')
+
+  t.end()
+})

--- a/visualizer/flame-graph-tooltip-container.js
+++ b/visualizer/flame-graph-tooltip-container.js
@@ -19,21 +19,19 @@ class FgTooltipContainer {
     this.svgPath = '/visualizer/assets/icons/'
 
     const html = `
-    <button class='zoom-button'>
-      <span class='icon'><img data-inline-svg class="icon-img zoom-in" src="/visualizer/assets/icons/zoom-in.svg" /><img data-inline-svg class="icon-img zoom-out" src="/visualizer/assets/icons/zoom-out.svg" /></span>
-      <span class='label'>Expand</span>
-    </button>
-    <button class='link-button'>
-      <span class='icon'><img data-inline-svg class="icon-img" src="/visualizer/assets/icons/link.svg" /></span>
-      <span>Open</span>
-      <span style="white-space: nowrap">in browser</span>
-    </button>
-    <button class='copy-button'>
-      <span class='icon'><img data-inline-svg class="icon-img" src="/visualizer/assets/icons/copy.svg" /></span>
-      <span>Copy</span>
-      <span>path</span>
-    </button>
-  `
+      <button class='zoom-button'>
+        <span class='icon'><img data-inline-svg class="icon-img zoom-in" src="/visualizer/assets/icons/zoom-in.svg" /><img data-inline-svg class="icon-img zoom-out" src="/visualizer/assets/icons/zoom-out.svg" /></span>
+        <span class='label'>Expand</span>
+      </button>
+      <button class='link-button'>
+        <span class='icon'><img data-inline-svg class="icon-img" src="/visualizer/assets/icons/link.svg" /></span>
+        <span>Open in browser</span>
+      </button>
+      <button class='copy-button'>
+        <span class='icon'><img data-inline-svg class="icon-img" src="/visualizer/assets/icons/copy.svg" /></span>
+        <span>Copy path</span>
+      </button>
+    `
     this.d3HiddenDiv = d3.select('body').insert('div', ':first-child')
       .style('visibility', 'hidden')
       .style('position', 'absolute')
@@ -56,9 +54,6 @@ class FgTooltipContainer {
       .on('click', () => {
         this.ui.zoomNode(this.nodeData)
       })
-
-    this.copyBtnChildren = this.d3TooltipCopyBtn.selectAll('span')
-    this.zoomBtnChildren = this.d3TooltipZoomBtn.selectAll('span')
   }
 
   show ({ nodeData, rect, pointerCoords, frameIsZoomed, wrapperNode, delay = null }) {

--- a/visualizer/flame-graph-tooltip-container.js
+++ b/visualizer/flame-graph-tooltip-container.js
@@ -2,7 +2,7 @@
 const d3 = require('d3')
 
 class FgTooltipContainer {
-  constructor ({ tooltip, showDelay = 700, hideDelay = 200, onCopyPath }) {
+  constructor ({ tooltip, showDelay = 700, hideDelay = 200, onCopyPath, onOpenPath }) {
     this.tooltip = tooltip
     this.ui = tooltip.ui
 
@@ -11,6 +11,7 @@ class FgTooltipContainer {
     this.showDelay = showDelay
     this.hideDelay = hideDelay
     this.onCopyPath = onCopyPath
+    this.onOpenPath = onOpenPath
 
     this.nodeData = null
     this.frameIsZoomed = false
@@ -21,6 +22,11 @@ class FgTooltipContainer {
     <button class='zoom-button'>
       <span class='icon'><img data-inline-svg class="icon-img zoom-in" src="/visualizer/assets/icons/zoom-in.svg" /><img data-inline-svg class="icon-img zoom-out" src="/visualizer/assets/icons/zoom-out.svg" /></span>
       <span class='label'>Expand</span>
+    </button>
+    <button class='link-button'>
+      <span class='icon'><img data-inline-svg class="icon-img" src="/visualizer/assets/icons/link.svg" /></span>
+      <span>Open</span>
+      <span style="white-space: nowrap">in browser</span>
     </button>
     <button class='copy-button'>
       <span class='icon'><img data-inline-svg class="icon-img" src="/visualizer/assets/icons/copy.svg" /></span>
@@ -39,6 +45,11 @@ class FgTooltipContainer {
     this.d3TooltipCopyBtn = this.d3TooltipHtml.select('.copy-button')
       .on('click', () => {
         this.onCopyPath && this.onCopyPath(this.nodeData.target)
+      })
+
+    this.d3TooltipLinkBtn = this.d3TooltipHtml.select('.link-button')
+      .on('click', () => {
+        this.onOpenPath && this.onOpenPath(this.nodeData.target)
       })
 
     this.d3TooltipZoomBtn = this.d3TooltipHtml.select('.zoom-button')
@@ -108,6 +119,10 @@ class FgTooltipContainer {
   }
 
   updateZoomBtnLabel () {
+    const isLink = /^https?:\/\//.test(this.nodeData.target)
+    this.d3TooltipCopyBtn.classed('hidden', isLink)
+    this.d3TooltipLinkBtn.classed('hidden', !isLink)
+
     this.d3TooltipZoomBtn.select('.label').text(this.frameIsZoomed ? 'Contract' : 'Expand')
 
     this.d3TooltipZoomBtn.classed('zoom-in', !this.frameIsZoomed)

--- a/visualizer/flame-graph-tooltip-container.js
+++ b/visualizer/flame-graph-tooltip-container.js
@@ -25,11 +25,11 @@ class FgTooltipContainer {
       </button>
       <button class='link-button'>
         <span class='icon'><img data-inline-svg class="icon-img" src="/visualizer/assets/icons/link.svg" /></span>
-        <span>Open in browser</span>
+        <span class='label'>Open in browser</span>
       </button>
       <button class='copy-button'>
         <span class='icon'><img data-inline-svg class="icon-img" src="/visualizer/assets/icons/copy.svg" /></span>
-        <span>Copy path</span>
+        <span class='label'>Copy path</span>
       </button>
     `
     this.d3HiddenDiv = d3.select('body').insert('div', ':first-child')

--- a/visualizer/flame-graph.css
+++ b/visualizer/flame-graph.css
@@ -102,12 +102,15 @@ chart > div {
   display: flex;
   flex-basis: 50%;
   font-size: inherit;
-  white-space: nowrap;
   justify-content: center;
   line-height: 1.2em;
   margin: 2px;
   outline: none;
   padding: 0;
+}
+
+.fg-tooltip-actions .label {
+  white-space: nowrap;
 }
 
 .fg-tooltip-actions button:hover {

--- a/visualizer/flame-graph.css
+++ b/visualizer/flame-graph.css
@@ -102,6 +102,7 @@ chart > div {
   display: flex;
   flex-basis: 50%;
   font-size: inherit;
+  white-space: nowrap;
   justify-content: center;
   line-height: 1.2em;
   margin: 2px;

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -91,6 +91,9 @@ class FlameGraph extends HtmlContent {
               <pre>${path}</pre>
             `, 4000)
           copy(path)
+        },
+        onOpenPath: (url) => {
+          window.open(url, '_blank')
         }
       })
     }


### PR DESCRIPTION
Adds a tooltip button when hovering Node Core frames. Clicking it opens the function definition's on Github in a new tab.