### PR TITLE
Store search state in URL hash.

### DIFF
--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -56,6 +56,14 @@ class FlameGraph extends HtmlContent {
     this.ui.on('updateExclusions', () => {
       this.sort()
     })
+
+    this.ui.on('clearSearch', () => {
+      this.flameGraph.clear(searchHighlightColor)
+    })
+
+    this.ui.on('search', (query) => {
+      this.flameGraph.search(query, searchHighlightColor)
+    })
   }
 
   initializeElements () {
@@ -315,14 +323,6 @@ class FlameGraph extends HtmlContent {
       this.draw()
     }
     this.updateMarkerBoxes()
-  }
-
-  clearSearch () {
-    this.flameGraph.clear(searchHighlightColor)
-  }
-
-  search (query) {
-    this.flameGraph.search(query, searchHighlightColor)
   }
 
   sort () {

--- a/visualizer/history.js
+++ b/visualizer/history.js
@@ -40,9 +40,14 @@ class History extends EventEmitter {
     }
   }
 
-  push (params) {
+  push (params, opts) {
     const hash = this.serialize(params)
-    window.history.pushState({ hash }, null, `${window.location.pathname}#${hash}`)
+    const path = `${window.location.pathname}#${hash}`
+    if (opts.replace) {
+      window.history.replaceState({ hash }, null, path)
+    } else {
+      window.history.pushState({ hash }, null, path)
+    }
   }
 
   serializeExcludes (exclude) {

--- a/visualizer/search-box.js
+++ b/visualizer/search-box.js
@@ -2,6 +2,18 @@ const HtmlContent = require('./html-content.js')
 const debounce = require('lodash.debounce')
 
 class SearchBox extends HtmlContent {
+  constructor (parentContent, contentProperties) {
+    super(parentContent, contentProperties)
+
+    this.ui.on('clearSearch', () => {
+      this.d3Input.property('value', null)
+    })
+
+    this.ui.on('search', (query) => {
+      this.d3Input.property('value', query)
+    })
+  }
+
   initializeElements () {
     super.initializeElements()
 

--- a/visualizer/search-box.js
+++ b/visualizer/search-box.js
@@ -6,7 +6,7 @@ class SearchBox extends HtmlContent {
     super(parentContent, contentProperties)
 
     this.ui.on('clearSearch', () => {
-      this.d3Input.property('value', null)
+      this.d3Input.property('value', '')
     })
 
     this.ui.on('search', (query) => {


### PR DESCRIPTION
When searching, the query is added to the hash as `&search=query here`. If the search query changes from something like `app` to `app.get`, it's assumed that the previous search was triggered while the user was still typing, and the hash is updated without creating a new history entry. This way you don't have to flick through a bunch of partial queries to go back in the history if you type slow.

This emits `search` and `clearSearch` events from UI so the SearchBox input can update, and moves the FlameGraph search() calls to also use those events.