### PR TITLE
Add --dest flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ const flame = new ClinicFlame()
 
 * settings [`<Object>`][]
   * detectPort [`<boolean>`][] **Default**: false
+  * debug [`<boolean>`][] If set to true, the generated html will not be minified.
+    **Default**: false
+  * dest [`<String>`][] The folder where the collected data is stored.
+    **Default**: '.'
 
 #### `flame.collect(args, callback)`
 
@@ -75,3 +79,4 @@ possible error.
 [clinic-url]: https://github.com/nearform/node-clinic
 [`<Object>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
 [`<boolean>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type
+[`<String>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String

--- a/collect/get-logging-paths.js
+++ b/collect/get-logging-paths.js
@@ -1,37 +1,5 @@
 'use strict'
 
-const path = require('path')
+const common = require('@nearform/clinic-common')
 
-function getLoggingPaths (options = {}) {
-  // TODO: make path configurable, like https://github.com/nearform/node-clinic-doctor/pull/165
-
-  let dirpath, basename
-  if (options.hasOwnProperty('identifier')) {
-    dirpath = ''
-    basename = options.identifier.toString()
-  } else if (options.hasOwnProperty('path')) {
-    dirpath = path.dirname(options.path)
-    basename = path.basename(options.path, '.clinic-flame')
-  } else {
-    dirpath = ''
-    basename = '{pid}' // pid is defined inside 0x process, then 0x will replace this string
-  }
-
-  const dirname = `${basename}.clinic-flame`
-  const systemInfoFilename = `${basename}.clinic-flame-systeminfo`
-  const inlinedFunctionsFilename = `${basename}.clinic-flame-inlinedfunctions`
-  const samplesFilename = `${basename}.clinic-flame-samples`
-
-  // TODO: Deprecate this and write smaller .clinic-flame-{dataType} files, similar to other tools
-  const zeroXDir = `${basename}.clinic-flame-0x-data`
-
-  return {
-    '/': path.join(dirpath, dirname),
-    '/systeminfo': path.join(dirpath, dirname, systemInfoFilename),
-    '/inlinedfunctions': path.join(dirpath, dirname, inlinedFunctionsFilename),
-    '/samples': path.join(dirpath, dirname, samplesFilename),
-    '/0x-data/': path.join(dirpath, dirname, zeroXDir)
-  }
-}
-
-module.exports = getLoggingPaths
+module.exports = common.getLoggingPaths('flame', ['/samples', '/inlinedfunctions', '/0x-data/'])

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ class ClinicFlame extends events.EventEmitter {
     const argv = args.slice(1)
     const self = this
 
-    const paths = getLoggingPaths()
+    const paths = getLoggingPaths({ identifier: '{pid}' })
 
     callbackify(x({
       argv,

--- a/index.js
+++ b/index.js
@@ -28,18 +28,23 @@ class ClinicFlame extends events.EventEmitter {
 
     const {
       detectPort = false,
-      debug = false
+      debug = false,
+      dest = null
     } = settings
 
     this.detectPort = detectPort
     this.debug = debug
+    this.path = dest
   }
 
   collect (args, cb) {
     const argv = args.slice(1)
     const self = this
 
-    const paths = getLoggingPaths({ identifier: '{pid}' })
+    const paths = getLoggingPaths({
+      path: this.path,
+      identifier: '{pid}' // replaced with actual pid by 0x
+    })
 
     callbackify(x({
       argv,
@@ -74,7 +79,7 @@ class ClinicFlame extends events.EventEmitter {
         })
       }
 
-      const paths = getLoggingPaths({ identifier: pid })
+      const paths = getLoggingPaths({ path: self.path, identifier: pid })
       fs.writeFile(paths['/systeminfo'], JSON.stringify(systemInfo(paths['/0x-data/']), null, 2), next)
       fs.writeFile(paths['/inlinedfunctions'], JSON.stringify(inlinedFunctions(paths['/0x-data/'])), next)
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "0x": "^4.5.1",
-    "@nearform/clinic-common": "^1.0.5",
+    "@nearform/clinic-common": "^1.1.0",
     "brfs": "^2.0.1",
     "browserify": "^16.2.2",
     "browserify-inline-svg": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "0x": "^4.5.1",
+    "@nearform/clinic-common": "^1.0.5",
     "brfs": "^2.0.1",
     "browserify": "^16.2.2",
     "browserify-inline-svg": "^1.0.2",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -108,3 +108,34 @@ test('cmd - test collect - system info, data files and html', function (t) {
     }
   )
 })
+
+test('cmd - test collect - custom output destination', (t) => {
+  const tool = new ClinicFlame({ debug: true, dest: 'test-output-destination' })
+
+  function cleanup (err, dirname) {
+    t.ifError(err)
+    t.match(dirname, /^test-output-destination\/[0-9]+\.clinic-flame$/)
+
+    rimraf('test-output-destination', (err) => {
+      t.ifError(err)
+      t.end()
+    })
+  }
+
+  tool.collect(
+    [process.execPath, path.join('test', 'fixtures', 'inspect.js')],
+    function (err, dirname) {
+      if (err) return cleanup(err, dirname)
+
+      t.ok(fs.statSync(dirname).isDirectory())
+
+      tool.visualize(dirname, `${dirname}.html`, (err) => {
+        if (err) return cleanup(err, dirname)
+
+        t.ok(fs.statSync(`${dirname}.html`).isFile())
+
+        cleanup(null, dirname)
+      })
+    }
+  )
+})

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -108,34 +108,3 @@ test('cmd - test collect - system info, data files and html', function (t) {
     }
   )
 })
-
-test('cmd - test collect - custom output destination', (t) => {
-  const tool = new ClinicFlame({ debug: true, dest: 'test-output-destination' })
-
-  function cleanup (err, dirname) {
-    t.ifError(err)
-    t.match(dirname, /^test-output-destination[\/\\][0-9]+\.clinic-flame$/)
-
-    rimraf('test-output-destination', (err) => {
-      t.ifError(err)
-      t.end()
-    })
-  }
-
-  tool.collect(
-    [process.execPath, path.join('test', 'fixtures', 'inspect.js')],
-    function (err, dirname) {
-      if (err) return cleanup(err, dirname)
-
-      t.ok(fs.statSync(dirname).isDirectory())
-
-      tool.visualize(dirname, `${dirname}.html`, (err) => {
-        if (err) return cleanup(err, dirname)
-
-        t.ok(fs.statSync(`${dirname}.html`).isFile())
-
-        cleanup(null, dirname)
-      })
-    }
-  )
-})

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -114,7 +114,7 @@ test('cmd - test collect - custom output destination', (t) => {
 
   function cleanup (err, dirname) {
     t.ifError(err)
-    t.match(dirname, /^test-output-destination\/[0-9]+\.clinic-flame$/)
+    t.match(dirname, /^test-output-destination[\/\\][0-9]+\.clinic-flame$/)
 
     rimraf('test-output-destination', (err) => {
       t.ifError(err)

--- a/test/cmd-dest.test.js
+++ b/test/cmd-dest.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs')
+const path = require('path')
+const { test } = require('tap')
+const rimraf = require('rimraf')
+const ClinicFlame = require('../index.js')
+
+test('cmd - test collect - custom output destination', (t) => {
+  const tool = new ClinicFlame({ debug: true, dest: 'test-output-destination' })
+
+  function cleanup (err, dirname) {
+    t.ifError(err)
+    t.match(dirname, /^test-output-destination[/\\][0-9]+\.clinic-flame$/)
+
+    rimraf('test-output-destination', (err) => {
+      t.ifError(err)
+      t.end()
+    })
+  }
+
+  tool.collect(
+    [process.execPath, path.join('test', 'fixtures', 'inspect.js')],
+    function (err, dirname) {
+      if (err) return cleanup(err, dirname)
+
+      t.ok(fs.statSync(dirname).isDirectory())
+
+      tool.visualize(dirname, `${dirname}.html`, (err) => {
+        if (err) return cleanup(err, dirname)
+
+        t.ok(fs.statSync(`${dirname}.html`).isFile())
+
+        cleanup(null, dirname)
+      })
+    }
+  )
+})

--- a/test/collect-get-logging-paths.test.js
+++ b/test/collect-get-logging-paths.test.js
@@ -28,8 +28,8 @@ test('Collect - logging path - path', function (t) {
   t.end()
 })
 
-test('Collect - logging path - defaults to 0x path templates', function (t) {
-  const paths = getLoggingPaths()
+test('Collect - logging path - supports 0x path templates', function (t) {
+  const paths = getLoggingPaths({ identifier: '{pid}' })
   t.strictDeepEqual(paths, {
     '/': path.normalize('{pid}.clinic-flame'),
     '/systeminfo': path.normalize('{pid}.clinic-flame/{pid}.clinic-flame-systeminfo'),

--- a/visualizer/d3.js
+++ b/visualizer/d3.js
@@ -7,7 +7,6 @@ const d3 = Object.assign(
   selection
 )
 
-
 // This property changes after importing so we fake a live binding.
 Object.defineProperty(d3, 'event', {
   get () { return selection.event }


### PR DESCRIPTION
This adds a `dest: 'path str'` option to Flame so the output location of the graphs and log data is configurable. With `dest: 'test-output-destination'`, files are placed in `test-output-destination/{pid}.clinic-flame`. This needed a change in `getLoggingPaths()`, that was already applied in clinic-common, so I figured this would be a good time to switch to clinic-common's implementation.

This requires https://github.com/nearform/node-clinic-common/pull/3 so clinic-common can support our Flame-specific files, tests pass with that patch.