### PR TITLE
Feature/update stackbar on zoom

### DIFF
--- a/visualizer/data-tree.js
+++ b/visualizer/data-tree.js
@@ -48,9 +48,16 @@ class DataTree {
     return false
   }
 
-  sortFramesByHottest () {
-    // Flattened tree, sorted hottest first, excluding the 'all stacks' root node
-    this.flatByHottest = this.getFlattenedSorted(this.getStackTopSorter())
+  sortFramesByHottest (customRootNode) {
+    if (customRootNode) {
+      // Flattened tree, sorted hottest first, including the root node
+      let frames = getFlatArray(customRootNode.children)
+      this.flatByHottest = this.getFlattenedSorted(this.getStackTopSorter(), [customRootNode].concat(frames))
+    } else {
+      // Flattened tree, sorted hottest first, excluding the 'all stacks' root node
+      this.flatByHottest = this.getFlattenedSorted(this.getStackTopSorter(), this.activeNodes())
+    }
+    this.highestStackTop = this.flatByHottest[0].onStackTop.asViewed
   }
 
   activeTree () {
@@ -70,8 +77,7 @@ class DataTree {
     this.update()
   }
 
-  getFlattenedSorted (sorter) {
-    const arr = this.activeNodes()
+  getFlattenedSorted (sorter, arr) {
     const filtered = arr.filter(node => !this.exclude.has(node.type))
     return filtered.sort(sorter)
   }

--- a/visualizer/selection-controls.js
+++ b/visualizer/selection-controls.js
@@ -15,10 +15,11 @@ class SelectionControls extends HtmlContent {
     // Show content for highlightedNode, or selectedNode when nothing is highlighted
     // so content falls back to most recent selection on frame mouseout etc
     this.ui.on('updateExclusions', () => {
-      this.countFrames()
-      const node = this.ui.highlightedNode || this.ui.selectedNode
-      this.rankNumber = this.ui.dataTree.getSortPosition(node)
-      this.draw()
+      this.update()
+    })
+
+    this.ui.on('zoomNode', () => {
+      this.update()
     })
 
     this.ui.on('selectNode', node => {
@@ -33,6 +34,13 @@ class SelectionControls extends HtmlContent {
       this.rankNumber = this.ui.dataTree.getSortPosition(node || this.selectedNode)
       this.draw()
     })
+  }
+
+  update () {
+    this.countFrames()
+    const node = this.ui.highlightedNode || this.ui.selectedNode
+    this.rankNumber = this.ui.dataTree.getSortPosition(node)
+    this.draw()
   }
 
   draw () {

--- a/visualizer/stack-bar.css
+++ b/visualizer/stack-bar.css
@@ -2,6 +2,7 @@
   position: relative;
   cursor: pointer;
   box-shadow: 0px -1px 0px rgba(255, 255, 255, 0.3) inset;
+  overflow: hidden;
 }
 
 #stack-bar .stack-frame {

--- a/visualizer/stack-bar.js
+++ b/visualizer/stack-bar.js
@@ -152,7 +152,6 @@ class StackBar extends HtmlContent {
     // flattening the children array and sorting the frames
     dataTree.sortFramesByHottest(this.ui.zoomedNode)
 
-    // const highest = dataTree.highestStackTop
     const availableWidth = this.d3Element.node().getBoundingClientRect().width
     const onePxPercent = 1 / availableWidth
 

--- a/visualizer/stack-bar.js
+++ b/visualizer/stack-bar.js
@@ -16,6 +16,10 @@ class StackBar extends HtmlContent {
     this.ui.on('selectNode', node => {
       this.pointToNode(node)
     })
+
+    this.ui.on('zoomNode', () => {
+      this.draw()
+    })
   }
 
   initializeElements () {
@@ -88,13 +92,15 @@ class StackBar extends HtmlContent {
     }
 
     const { dataTree } = this.ui
-    const rootNode = dataTree.activeTree()
+    const rootNode = this.ui.zoomedNode || dataTree.activeTree()
     const highest = dataTree.highestStackTop
     const availableWidth = this.d3Element.node().getBoundingClientRect().width
     const onePxPercent = 1 / availableWidth
 
     const frames = []
     let usedWidth = 0.0
+
+    dataTree.sortFramesByHottest(this.ui.zoomedNode)
 
     for (let i = 0; i < dataTree.flatByHottest.length; i++) {
       const d = dataTree.flatByHottest[i]

--- a/visualizer/stack-bar.js
+++ b/visualizer/stack-bar.js
@@ -93,14 +93,16 @@ class StackBar extends HtmlContent {
 
     const { dataTree } = this.ui
     const rootNode = this.ui.zoomedNode || dataTree.activeTree()
+
+    // flattening the children array and sorting the frames
+    dataTree.sortFramesByHottest(this.ui.zoomedNode)
+
     const highest = dataTree.highestStackTop
     const availableWidth = this.d3Element.node().getBoundingClientRect().width
     const onePxPercent = 1 / availableWidth
 
     const frames = []
     let usedWidth = 0.0
-
-    dataTree.sortFramesByHottest(this.ui.zoomedNode)
 
     for (let i = 0; i < dataTree.flatByHottest.length; i++) {
       const d = dataTree.flatByHottest[i]


### PR DESCRIPTION
When zooming in/out the stack-bar updates itself to reflect the nodes data actually displayed.
`Selection-controls` gets updated as well