### PR TITLE
Make long descriptions appear over the next item on hover, fixes #25

### DIFF
--- a/visualizer/options-menu.css
+++ b/visualizer/options-menu.css
@@ -86,20 +86,33 @@
   transform-origin: 50%;
 }
 
+#options-menu .options .overflow-wrapper {
+  height: 2.8em;
+  position: relative;
+}
 
 #options-menu .options label:hover {
   white-space: normal;
-  background-color: rgba(255, 255, 255, 0.06);
+  /* background of options area mixed with:
+   *   rgba(255, 255, 255, 0.06)
+   * included as a constant value so this colour
+   * obscures the lower items that it overflows on hover. */
+  background-color: rgb(53, 55, 65);
+  height: auto;
+  z-index: 3;
 }
 
 #options-menu .options label {
+  position: absolute;
+  width: 100%;
   opacity: 0.8;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   cursor: pointer;
-  height: 2.8em;
+  height: 100%;
+  min-height: 100%;
   line-height: 1.3;
-  padding: 0 5px;
+  padding: 0.7em 5px;
 }
 
 #options-menu .options li.disabled {

--- a/visualizer/options-menu.css
+++ b/visualizer/options-menu.css
@@ -97,7 +97,7 @@
    *   rgba(255, 255, 255, 0.06)
    * included as a constant value so this colour
    * obscures the lower items that it overflows on hover. */
-  background-color: rgb(53, 55, 65);
+  background-color: rgb(66, 69, 81);
   height: auto;
   z-index: 3;
 }

--- a/visualizer/options-menu.js
+++ b/visualizer/options-menu.js
@@ -78,7 +78,9 @@ class OptionsMenu extends HtmlContent {
   addFgOptionCheckbox ({ id, name, description, onChange }) {
     const li = this.d3FgOptions.select('ul').append('li')
       .attr('id', id)
-    const label = li.append('label')
+    const wrapper = li.append('div')
+      .classed('overflow-wrapper', true)
+    const label = wrapper.append('label')
     const d3Checkbox = label.append('input')
       .attr('type', 'checkbox')
       .on('click', () => {
@@ -89,9 +91,9 @@ class OptionsMenu extends HtmlContent {
     label.append('span')
       .classed('icon-wrapper', true)
       .html(`
-      <img class="icon-img checked" data-inline-svg src="/visualizer/assets/icons/checkbox-checked.svg" />
-      <img class="icon-img unchecked" data-inline-svg src="/visualizer/assets/icons/checkbox-unchecked.svg" />
-      <img class="icon-img indetermined" data-inline-svg src="/visualizer/assets/icons/checkbox-indetermined.svg" />
+        <img class="icon-img checked" data-inline-svg src="/visualizer/assets/icons/checkbox-checked.svg" />
+        <img class="icon-img unchecked" data-inline-svg src="/visualizer/assets/icons/checkbox-unchecked.svg" />
+        <img class="icon-img indetermined" data-inline-svg src="/visualizer/assets/icons/checkbox-indetermined.svg" />
       `)
 
     const copyWrapper = label.append('span')
@@ -159,7 +161,9 @@ class OptionsMenu extends HtmlContent {
     // for use with a d3.enter() selection.
     function createOptionElement (li) {
       li.classed('visible', d => d.visible === true)
-      const label = li.append('label')
+      const wrapper = li.append('div')
+        .classed('overflow-wrapper', true)
+      const label = wrapper.append('label')
         .attr('title', d => d.title)
       label.append('input')
         .attr('type', 'checkbox')


### PR DESCRIPTION
This prevents long code area descriptions from overflowing the
background colour, making text hard to read.

A `position:relative` wrapper div is used so the `<li>` boxes still
have the same size as before.

`position:absolute` allows the elements to overflow the `<li>` box, but
not the `<label>`; labels now have a solid background colour when hovered
so you can still read them (more or less) when they overflow.

Before:

![image](https://user-images.githubusercontent.com/1006268/48253903-cae9ee80-e408-11e8-80f0-bd1f16bf14c6.png)

After:

![image](https://user-images.githubusercontent.com/1006268/48619914-67c70180-e99e-11e8-8171-b3524085ce71.png)