### PR TITLE
Fix "More info" links in options menu

### DIFF
--- a/visualizer/options-menu.js
+++ b/visualizer/options-menu.js
@@ -231,12 +231,12 @@ class OptionsMenu extends HtmlContent {
         description: 'The Node.js framework and its dependencies',
         childrenVisibilityToggle: true,
         children: [
-          { id: 'core', visible: true, description: `JS functions in core Node.js APIs. <a target="_blank" class="more-info href="https://clinicjs.org/flame/walkthrough/controls/#core">More info</a>` },
-          { id: 'native', visible: true, description: `JS compiled into V8, such as prototype methods and eval. <a target="_blank" class="more-info href="https://clinicjs.org/flame/walkthrough/controls/#native">More info</a>` },
-          { id: 'v8', description: `Operations in V8's implementation of JS. <a target="_blank" class="more-info href="https://clinicjs.org/flame/walkthrough/controls/#v8">More info</a>` },
-          { id: 'cpp', description: `Native C++ operations called by V8, including shared libraries. <a target="_blank" class="more-info href="https://clinicjs.org/flame/walkthrough/controls/#cpp">More info</a>` },
-          { id: 'regexp', description: `The RegExp notation is shown as the function name. <a target="_blank" class="more-info href="https://clinicjs.org/flame/walkthrough/controls/#rx">More info</a>` },
-          { id: 'init', description: `Any of the above that are repeated frequently during initialization. <a target="_blank" class="more-info href="https://clinicjs.org/flame/walkthrough/controls/#init">More info</a>` }
+          { id: 'core', visible: true, description: `JS functions in core Node.js APIs. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#core">More info</a>` },
+          { id: 'native', visible: true, description: `JS compiled into V8, such as prototype methods and eval. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#native">More info</a>` },
+          { id: 'v8', description: `Operations in V8's implementation of JS. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#v8">More info</a>` },
+          { id: 'cpp', description: `Native C++ operations called by V8, including shared libraries. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#cpp">More info</a>` },
+          { id: 'regexp', description: `The RegExp notation is shown as the function name. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#rx">More info</a>` },
+          { id: 'init', description: `Any of the above that are repeated frequently during initialization. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#init">More info</a>` }
         ] }
     ]
 


### PR DESCRIPTION
The `class="` attribute was never closed for these elements, causing
html parsing to fail, but not fail badly enough, so the links were
still visible, just didn't work.