### PR TITLE
Avoid rerendering flame graph if size hasn't changed

### DIFF
--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -31,6 +31,7 @@ class FlameGraph extends HtmlContent {
     this.isAnimating = false
     this.baseCellHeight = 20
     this.cellHeight = this.baseCellHeight + this.zoomFactor
+    this.sizeChanged = false
 
     this.tooltip = contentProperties.customTooltip
     this.showOptimizationStatus = contentProperties.showOptimizationStatus
@@ -323,8 +324,11 @@ class FlameGraph extends HtmlContent {
     this.zoomFactorChanged = this.zoomFactor !== zoomFactor
     this.zoomFactor = zoomFactor
 
-    this.width = this.d3Chart.node().clientWidth
-    this.cellHeight = this.baseCellHeight + zoomFactor
+    const width = this.d3Chart.node().clientWidth
+    const cellHeight = this.baseCellHeight + zoomFactor
+    this.sizeChanged = this.width !== width || this.cellHeight !== cellHeight
+    this.width = width
+    this.cellHeight = cellHeight
     this.draw()
     this.updateMarkerBoxes()
   }
@@ -342,8 +346,11 @@ class FlameGraph extends HtmlContent {
     super.draw()
 
     const { dataTree } = this.ui
-    this.flameGraph.width(this.width)
-    this.flameGraph.cellHeight(this.cellHeight)
+    if (this.sizeChanged) {
+      this.flameGraph.width(this.width)
+      this.flameGraph.cellHeight(this.cellHeight)
+      this.sizeChanged = false
+    }
 
     let redrawGraph = false
 


### PR DESCRIPTION
`fg.cellHeight()` and `fg.width()` immediately rerender the graph, so
doing it unconditionally is quite expensive.

With this patch we rerender far less frequently, and an update just
causes 1 render instead of 3(!). If the size changed, we still do 2
renders, because of how d3-fg works … maybe we could use
`requestAnimationFrame` in d3-fg to batch updates, but that would
likely be a breaking change, and we rely on filter updates etc. being
processed synchronously in Flame.