### PR TITLE
Show frame count on initial load

### DIFF
--- a/visualizer/selection-controls.js
+++ b/visualizer/selection-controls.js
@@ -21,6 +21,10 @@ class SelectionControls extends HtmlContent {
       this.draw()
     })
 
+    this.ui.on('setData', () => {
+      this.countFrames()
+    })
+
     this.ui.on('selectNode', node => {
       if (!node) return
       this.selectedNode = node


### PR DESCRIPTION
A bug crept in where the number of frames was no longer reliably shown on initial load:

![image](https://user-images.githubusercontent.com/29628323/48673452-7c8bcc80-eb39-11e8-888b-6d090490708d.png)

This fixes it:

![image](https://user-images.githubusercontent.com/29628323/48673454-90373300-eb39-11e8-90f7-7bd18fce3cf9.png)
