### PR TITLE
Simplify code area categories

### DIFF
--- a/analysis/index.js
+++ b/analysis/index.js
@@ -27,8 +27,6 @@ async function analyse (paths) {
     { id: 'app' },
     { id: 'deps' },
     { id: 'core' },
-    // This is a "virtual" code area, it overlaps with other areas.
-    { id: 'init' },
     { id: 'all-v8',
       children: [
         { id: 'v8' },

--- a/analysis/index.js
+++ b/analysis/index.js
@@ -23,6 +23,20 @@ async function analyse (paths) {
   const appName = platformPath.basename(systemInfo.mainDirectory)
   const pathSeparator = systemInfo.pathSeparator
 
+  const codeAreas = [
+    { id: 'app' },
+    { id: 'deps' },
+    { id: 'core' },
+    { id: 'all-v8',
+      children: [
+        { id: 'v8' },
+        { id: 'native' },
+        { id: 'cpp' },
+        { id: 'regexp' }
+      ],
+      childrenVisibilityToggle: true }
+  ]
+
   const steps = [
     (tree) => labelNodes(tree),
     (tree) => tree.walk((node) => {
@@ -43,6 +57,7 @@ async function analyse (paths) {
   return {
     appName,
     pathSeparator,
+    codeAreas,
     merged,
     unmerged
   }

--- a/analysis/index.js
+++ b/analysis/index.js
@@ -27,6 +27,8 @@ async function analyse (paths) {
     { id: 'app' },
     { id: 'deps' },
     { id: 'core' },
+    // This is a "virtual" code area, it overlaps with other areas.
+    { id: 'init' },
     { id: 'all-v8',
       children: [
         { id: 'v8' },

--- a/visualizer/data-tree.js
+++ b/visualizer/data-tree.js
@@ -9,6 +9,8 @@ class DataTree {
     this.merged = tree.merged
     this.unmerged = tree.unmerged
 
+    this.codeAreas = tree.codeAreas
+
     // Set a reasonable upper limit to displayed name; exact name matching is done in analysis
     this.appName = tree.appName.length > 30 ? tree.appName.slice(0, 30) + '…' : tree.appName
     this.pathSeparator = tree.pathSeparator

--- a/visualizer/options-menu.css
+++ b/visualizer/options-menu.css
@@ -99,7 +99,6 @@
 #options-menu .options label {
   position: absolute;
   width: 100%;
-  opacity: 0.8;
   display: flex;
   align-items: flex-start;
   cursor: pointer;

--- a/visualizer/options-menu.js
+++ b/visualizer/options-menu.js
@@ -58,13 +58,23 @@ class OptionsMenu extends HtmlContent {
     this.d3FgOptions = this.d3OptionsList.append('div')
       .classed('section', true)
     this.d3FgOptions.append('h2')
-      .text('Merging and highlighting')
+      .text('Advanced')
     this.d3FgOptions.append('ul')
+
+    this.d3InitCheckbox = this.addFgOptionCheckbox({
+      id: 'option-init',
+      name: 'Init',
+      description: 'Show initialization operations hidden by default, like module loading',
+      onChange: (checked) => {
+        ui.setCodeAreaVisibility('init', checked)
+        ui.draw()
+      }
+    })
 
     this.d3MergeCheckbox = this.addFgOptionCheckbox({
       id: 'option-usemergedtree',
       name: 'Merge',
-      description: 'joins optimized and unoptimized versions of frames',
+      description: 'Join optimized and unoptimized versions of frames',
       onChange: (checked) => {
         this.ui.setUseMergedTree(checked)
       }
@@ -73,7 +83,7 @@ class OptionsMenu extends HtmlContent {
     this.d3OptCheckbox = this.addFgOptionCheckbox({
       id: 'option-showoptimizationstatus',
       name: 'Show optimization status',
-      description: 'highlight frames that are optimized functions',
+      description: 'Highlight frames that are optimized functions',
       onChange: (checked) => {
         this.ui.setShowOptimizationStatus(checked)
       }
@@ -113,21 +123,21 @@ class OptionsMenu extends HtmlContent {
     true) // using useCapture here so that we can handle the event before `.showMore` button updates its content
   }
 
-  addFgOptionCheckbox ({ id, name, description, onChange }, parentNode) {
-    parentNode = parentNode || this.d3FgOptions.select('ul')
-    const li = parentNode.append('li')
+  addFgOptionCheckbox ({ id, name, description, onChange }, d3ParentNode) {
+    d3ParentNode = d3ParentNode || this.d3FgOptions.select('ul')
+    const d3Li = d3ParentNode.append('li')
       .attr('id', id)
-    const wrapper = li.append('div')
+    const d3Wrapper = d3Li.append('div')
       .classed('overflow-wrapper', true)
-    const label = wrapper.append('label')
-    const d3Checkbox = label.append('input')
+    const d3Label = d3Wrapper.append('label')
+    const d3Checkbox = d3Label.append('input')
       .attr('type', 'checkbox')
       .on('click', () => {
         const { checked } = d3.event.target
         onChange(checked)
       })
 
-    label.append('span')
+    d3Label.append('span')
       .classed('icon-wrapper', true)
       .html(`
         <img class="icon-img checked" data-inline-svg src="/visualizer/assets/icons/checkbox-checked.svg" />
@@ -135,13 +145,13 @@ class OptionsMenu extends HtmlContent {
         <img class="icon-img indetermined" data-inline-svg src="/visualizer/assets/icons/checkbox-indetermined.svg" />
       `)
 
-    const copyWrapper = label.append('span')
+    const d3CopyWrapper = d3Label.append('span')
       .classed('copy-wrapper', true)
-    copyWrapper.append('span')
+    d3CopyWrapper.append('span')
       .classed('name', true)
       .text(name)
     if (description) {
-      copyWrapper.append('span')
+      d3CopyWrapper.append('span')
         .classed('description', true)
         .html(` - ${description}`)
     }
@@ -299,15 +309,14 @@ class OptionsMenu extends HtmlContent {
     super.draw()
 
     // Update option checkbox values.
-    const { useMerged, showOptimizationStatus, appName } = this.ui.dataTree
-    this.d3FgOptions.select('#option-usemergedtree')
-      .select('input')
-      .property('checked', useMerged)
-    this.d3FgOptions.select('#option-showoptimizationstatus')
-      .classed('disabled', useMerged)
-      .select('input')
+    const { useMerged, showOptimizationStatus, exclude, appName } = this.ui.dataTree
+    this.d3MergeCheckbox.property('checked', useMerged)
+    this.d3OptCheckbox
       .attr('disabled', useMerged ? 'disabled' : null)
       .property('checked', showOptimizationStatus)
+      .select(function () { return this.closest('li') })
+      .classed('disabled', useMerged)
+    this.d3InitCheckbox.property('checked', !exclude.has('init'))
 
     // Updating the app name
     this.d3VisibilityOptions.select('.name')

--- a/visualizer/options-menu.js
+++ b/visualizer/options-menu.js
@@ -14,32 +14,6 @@ const preferences = [
   }
 ]
 
-function getCodeAreaDescription (area) {
-  const { id } = area
-
-  if (id === 'all-core') {
-    return 'The Node.js framework and its dependencies'
-  }
-  if (id === 'core') {
-    return `JS functions in core Node.js APIs. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#core">More info</a>`
-  }
-  if (id === 'native') {
-    return `JS compiled into V8, such as prototype methods and eval. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#native">More info</a>`
-  }
-  if (id === 'v8' || id === 'all-v8') {
-    return `Operations in V8's implementation of JS. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#v8">More info</a>`
-  }
-  if (id === 'cpp') {
-    return `Native C++ operations called by V8, including shared libraries. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#cpp">More info</a>`
-  }
-  if (id === 'regexp') {
-    return `The RegExp notation is shown as the function name. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#rx">More info</a>`
-  }
-  if (id === 'init') {
-    return `Any of the above that are repeated frequently during initialization. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#init">More info</a>`
-  }
-}
-
 class OptionsMenu extends HtmlContent {
   constructor (parentContent, contentProperties) {
     super(parentContent, contentProperties)
@@ -249,7 +223,7 @@ class OptionsMenu extends HtmlContent {
       copyWrapper.append('description')
         .classed('description', true)
         .html((d) => {
-          const description = getCodeAreaDescription(d)
+          const description = ui.getDescriptionFromKey(d.id)
           return description ? ` - ${description}` : ''
         })
     }

--- a/visualizer/options-menu.js
+++ b/visualizer/options-menu.js
@@ -66,8 +66,8 @@ class OptionsMenu extends HtmlContent {
       name: 'Init',
       description: 'Show initialization operations hidden by default, like module loading',
       onChange: (checked) => {
-        ui.setCodeAreaVisibility('init', checked)
-        ui.draw()
+        this.ui.setCodeAreaVisibility('init', checked)
+        this.ui.draw()
       }
     })
 

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -378,7 +378,7 @@ class Ui extends events.EventEmitter {
       'native': `JS compiled into V8, such as prototype methods and eval. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#native">More info</a>`,
       'cpp': `Native C++ operations called by V8, including shared libraries. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#cpp">More info</a>`,
       'regexp': `The RegExp notation is shown as the function name. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#rx">More info</a>`,
-      'init': `Any of the above that are repeated frequently during initialization. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#init">More info</a>`,
+      'init': `Module loading and other operations during initialization. Frames in this category also belong to other categories. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#init">More info</a>`,
     }
 
     return keysToDescriptions[key] || null

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -360,6 +360,7 @@ class Ui extends events.EventEmitter {
       'all-core': 'Core',
 
       'core': 'Node JS',
+      'all-v8': 'V8',
       'native': 'V8 native',
       'v8': 'V8 runtime',
       'cpp': 'V8 C++',

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -364,8 +364,7 @@ class Ui extends events.EventEmitter {
       'native': 'V8 native',
       'v8': 'V8 runtime',
       'cpp': 'V8 C++',
-      'regexp': 'RegExp',
-      'init': 'Init'
+      'regexp': 'RegExp'
     }
     return keysToLabels[key] || key
   }
@@ -373,12 +372,11 @@ class Ui extends events.EventEmitter {
   getDescriptionFromKey (key) {
     const keysToDescriptions = {
       'core': `JS functions in core Node.js APIs. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#core">More info</a>`,
-      'all-v8': 'The V8 engine JavaScript implementation',
+      'all-v8': 'The JavaScript engine used by default in Node.js',
       'v8': `Operations in V8's implementation of JS. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#v8">More info</a>`,
       'native': `JS compiled into V8, such as prototype methods and eval. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#native">More info</a>`,
       'cpp': `Native C++ operations called by V8, including shared libraries. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#cpp">More info</a>`,
-      'regexp': `The RegExp notation is shown as the function name. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#rx">More info</a>`,
-      'init': `Module loading and other operations during initialization. Frames in this category also belong to other categories. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#init">More info</a>`,
+      'regexp': `The RegExp notation is shown as the function name. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#rx">More info</a>`
     }
 
     return keysToDescriptions[key] || null

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -370,6 +370,20 @@ class Ui extends events.EventEmitter {
     return keysToLabels[key] || key
   }
 
+  getDescriptionFromKey (key) {
+    const keysToDescriptions = {
+      'core': `JS functions in core Node.js APIs. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#core">More info</a>`,
+      'all-v8': 'The V8 engine JavaScript implementation',
+      'v8': `Operations in V8's implementation of JS. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#v8">More info</a>`,
+      'native': `JS compiled into V8, such as prototype methods and eval. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#native">More info</a>`,
+      'cpp': `Native C++ operations called by V8, including shared libraries. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#cpp">More info</a>`,
+      'regexp': `The RegExp notation is shown as the function name. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#rx">More info</a>`,
+      'init': `Any of the above that are repeated frequently during initialization. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#init">More info</a>`,
+    }
+
+    return keysToDescriptions[key] || null
+  }
+
   setCodeAreaVisibility (name, visible, manyTimes) {
     // Apply a single possible change to dataTree.exclude, updating what's necessary
     let isChanged = false


### PR DESCRIPTION
Changes the list to:

![image](https://user-images.githubusercontent.com/1006268/48830056-fd360d00-ed73-11e8-8183-569e4f01b6d2.png)

- [x] This still needs to do something with [INIT] frames, probably as a separate checkbox, building on Alan's PR that allows custom exclusion filters for d3-fg. They could be chucked under Core for now but if that PR is landing soon anyway we can also stack this PR on top of that one.

Just added it as another filter option like before, since it will keep using the `dataTree.exclude` property anyway.