### PR TITLE
Fix errors on applying unmerged tree from hash

### DIFF
--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -357,28 +357,28 @@ class FlameGraph extends HtmlContent {
     const { toHide, toShow } = this.ui.changedExclusions
     let isChanged = false
 
+    if (this.zoomFactorChanged) {
+      redrawGraph = true
+      this.zoomFactorChanged = false
+    }
+
+    // Must re-render tree before applying exclusions, else error if tree and exclusions change at same time
+    if (redrawGraph) this.flameGraph.renderTree(this.renderedTree)
+
     if (toHide.size > 0) {
       toHide.forEach((name) => {
         this.flameGraph.typeHide(name)
-        redrawGraph = false
       })
       isChanged = true
     }
     if (toShow.size > 0) {
       toShow.forEach((name) => {
         this.flameGraph.typeShow(name)
-        redrawGraph = false
       })
       isChanged = true
     }
 
-    if (this.zoomFactorChanged) {
-      redrawGraph = true
-      this.zoomFactorChanged = false
-    }
-
     if (isChanged || redrawGraph) this.updateMarkerBoxes()
-    if (redrawGraph) this.flameGraph.renderTree(this.renderedTree)
   }
 }
 

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -37,12 +37,16 @@ class FlameGraph extends HtmlContent {
     this.labelFont = contentProperties.labelFont
     this.labelPadding = contentProperties.labelPadding
 
+    this.onNextAnimationEnd = null
+
     this.ui.on('setData', () => {
       this.initializeFromData()
     })
 
-    this.ui.on('zoomNode', node => {
+    this.ui.on('zoomNode', (node, cb) => {
       if (this.flameGraph) {
+        if (cb) this.onNextAnimationEnd = cb
+
         this.isAnimating = true
         this.zoomedNodeData = node
 
@@ -53,6 +57,8 @@ class FlameGraph extends HtmlContent {
         this.markNodeAsSelected(null)
         this.markNodeAsZoomed(null)
         this.flameGraph.zoom(node || this.ui.dataTree.activeTree())
+      } else {
+        if (cb) cb()
       }
     })
 
@@ -231,6 +237,11 @@ class FlameGraph extends HtmlContent {
       } else {
         this.hoveredNodeData = this.ui.highlightedNode || this.ui.selectedNode
         this.highlightHoveredNodeOnGraph()
+      }
+
+      if (this.onNextAnimationEnd) {
+        this.onNextAnimationEnd()
+        this.onNextAnimationEnd = null
       }
     })
 

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -50,7 +50,8 @@ class Ui extends events.EventEmitter {
   }
 
   updateFromHistory (data) {
-    this.dataTree.useMerged = data.useMerged
+    this.setUseMergedTree(data.useMerged, { pushState: false })
+
     this.dataTree.showOptimizationStatus = data.showOptimizationStatus
 
     let anyChanges = false
@@ -361,17 +362,20 @@ class Ui extends events.EventEmitter {
     }
   }
 
-  setUseMergedTree (useMerged) {
+  setUseMergedTree (useMerged, { pushState = true } = {}) {
     if (this.dataTree.useMerged === useMerged) {
       return
     }
 
     this.dataTree.setActiveTree(useMerged)
 
+    // Current ui.selectedNode will be in wrong tree, therefore may cause errors during draw.
+    // Just erase instead of using ui.selectNode() - that will be called in this.selectHottestNode()
+    this.selectedNode = null
     this.draw()
     this.selectHottestNode()
 
-    this.pushHistory()
+    if (pushState) this.pushHistory()
   }
 
   setShowOptimizationStatus (showOptimizationStatus) {

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -82,8 +82,8 @@ class Ui extends events.EventEmitter {
       // Redraw before zooming to make sure these nodes are visible in the flame graph.
       this.draw()
 
-      this.selectNode(this.dataTree.getNodeById(selectedNodeId), { pushState: false })
       this.zoomNode(this.dataTree.getNodeById(zoomedNodeId), { pushState: false })
+      this.selectNode(this.dataTree.getNodeById(selectedNodeId), { pushState: false })
 
       if (search !== this.searchQuery) {
         this.search(search, { pushState: false })

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -103,7 +103,7 @@ class Ui extends events.EventEmitter {
 
   // Persistent e.g. on click, then falls back to this after mouseout
   selectNode (node = null, { pushState = true } = {}) {
-    if ((node && node.id === 0) || !node) return
+    if (!node || node.id === 0) return
     const changed = node !== this.selectedNode
     this.selectedNode = node
     if (changed) this.emit('selectNode', node)

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -376,11 +376,13 @@ class Ui extends events.EventEmitter {
       return
     }
 
+    // Current selected and zoomed nodes will be in wrong tree, therefore may cause errors during draw.
+    // ui.selectNode() will be called properly in this.selectHottestNode() or based on selectedNodeId.
+    this.selectedNode = null
+    this.zoomNode(null)
+
     this.dataTree.setActiveTree(useMerged)
 
-    // Current ui.selectedNode will be in wrong tree, therefore may cause errors during draw.
-    // Just erase instead of using ui.selectNode() - that will be called in this.selectHottestNode()
-    this.selectedNode = null
     this.draw()
     if (!selectedNodeId) this.selectHottestNode()
 


### PR DESCRIPTION
I found a couple of nasty bugs in setting the active tree based on the hash:

- Changing the tree to unmerged and then refreshing the page can cause errors because changing the tree from the hash simply changes the property without calling the datatree update chain. This changes it to use the existing `dataTree.setUseMergedTree()` method
- It's possible to then get timing errors due to the flamegraph trying to select or zoom a node from the wrong tree. This zooms out then clears the .selectedNode property while updating the tree
- There's also a potential timing error this fixes if a hash contains both a change from the default (merged) tree and changes to exclusions, because it tries to apply the exclusions to the wrong tree. This fixes that, too

