### PR TITLE
Design and presentation mode adjustments

### DIFF
--- a/visualizer/flame-graph-frame.js
+++ b/visualizer/flame-graph-frame.js
@@ -25,6 +25,7 @@ function renderStackFrame (globals, locals, rect) {
   const thick = 3
   const thin = 1
   const lineWidth = this.ui.presentationMode ? thick : thin
+  const heatHeight = Math.ceil(rect.height / (this.ui.presentationMode ? 2.5 : 3))
 
   // Do nothing for frames excluded by zoom, unless we're still animating
   if (nodeData.value === 0 && !this.isAnimating) return
@@ -40,13 +41,15 @@ function renderStackFrame (globals, locals, rect) {
   if (width <= 1.5) {
     const backgroundColor = this.ui.getFrameColor(nodeData, 'background', false)
     const foregroundColor = this.ui.getFrameColor(nodeData, 'foreground', false)
-    renderAsLine(context, { x: left, y, height }, backgroundColor, foregroundColor, nodeData.highlight)
+    renderAsLine(context, { x: left, y, height }, backgroundColor, foregroundColor, nodeData.highlight, heatHeight)
     return
   }
 
   // Don't redraw heat over previous paint on hover events, and don't draw for root node
   // if (state === STATE_IDLE && nodeData.id !== 0) renderHeatBar(context, nodeData, colorHash, alignedRect)
-  if (state === STATE_IDLE && nodeData.id !== 0) renderHeatBar(context, nodeData, colorHash, rect)
+  if (state === STATE_IDLE && nodeData.id !== 0) {
+    renderHeatBar(context, nodeData, colorHash, rect, heatHeight)
+  }
 
   const backgroundColor = this.ui.getFrameColor(nodeData, 'background')
   const foregroundColor = this.ui.getFrameColor(nodeData, 'foreground')
@@ -82,11 +85,10 @@ function renderStackFrame (globals, locals, rect) {
   context.restore()
 }
 
-function renderHeatBar (context, nodeData, colorHash, rect) {
+function renderHeatBar (context, nodeData, colorHash, rect, heatHeight) {
   // Extracted from d3-fg so we can pixel-align it to match the rest
   const heatColor = colorHash(nodeData)
   const heatStrokeColor = colorHash(nodeData, 1.1)
-  const heatHeight = getHeatHeight(rect.height)
 
   context.fillStyle = heatColor
   context.strokeStyle = heatStrokeColor
@@ -96,7 +98,7 @@ function renderHeatBar (context, nodeData, colorHash, rect) {
   context.stroke()
 }
 
-function renderAsLine (context, rect, backgroundColor, foregroundColor, isHighlighted) {
+function renderAsLine (context, rect, backgroundColor, foregroundColor, isHighlighted, heatHeight) {
   const {
     x,
     y,
@@ -106,7 +108,7 @@ function renderAsLine (context, rect, backgroundColor, foregroundColor, isHighli
   // Black solid background line, including black heat area
   context.strokeStyle = backgroundColor
   context.beginPath()
-  context.moveTo(x, y - getHeatHeight(height))
+  context.moveTo(x, y - heatHeight)
   context.lineTo(x, y + height)
   context.stroke()
 
@@ -121,10 +123,6 @@ function renderAsLine (context, rect, backgroundColor, foregroundColor, isHighli
   context.lineTo(x, y + height)
   context.stroke()
   context.restore()
-}
-
-function getHeatHeight (height) {
-  return Math.ceil(height / 3)
 }
 
 module.exports = getFrameRenderer

--- a/visualizer/flame-graph.css
+++ b/visualizer/flame-graph.css
@@ -88,10 +88,10 @@ chart > div {
 
 .fg-tooltip-actions {
   display: flex;
-  background-color: rgba(0, 0, 0, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.5);
+  background-color: var(--opposite-translucent);
+  border: 1px solid var(--primary-grey);
   color: white;
-  font-size: var(--normal-text-size);;
+  font-size: var(--normal-text-size);
 }
 
 .fg-tooltip-actions button {
@@ -106,9 +106,8 @@ chart > div {
   font-size: inherit;
   justify-content: center;
   line-height: 1.2em;
-  margin: 2px;
+  padding: 2px;
   outline: none;
-  padding: 0;
 }
 
 .fg-tooltip-actions .label {
@@ -116,7 +115,8 @@ chart > div {
 }
 
 .fg-tooltip-actions button:hover {
-  background-color: var(--light-glare);
+  background-color: var(--opposite-contrast);
+  outline: 1px solid var(--max-contrast);
 }
 
 .fg-tooltip-actions .zoom-button svg {

--- a/visualizer/flame-graph.css
+++ b/visualizer/flame-graph.css
@@ -83,20 +83,20 @@ chart > div {
   position: absolute;
   pointer-events: none;
   border-top: 3px solid var(--main-bg-color);
-  background: linear-gradient(to bottom, rgba(0,0,0,0.8), rgba(0,0,0,0));
+  background: linear-gradient(to bottom, rgba(var(--opposite-color-val), 0.8), rgba(var(--opposite-color-val), 0));
 }
 
 .fg-tooltip-actions {
   display: flex;
-  background-color: var(--opposite-translucent);
+  background-color: rgba(var(--opposite-color-val), 0.8);
   border: 1px solid var(--primary-grey);
   color: white;
   font-size: var(--normal-text-size);
 }
 
 .fg-tooltip-actions button {
+  background-color: transparent;
   align-items: center;
-  background-color: var(--opposite-translucent);
   border-radius: 0;
   border: none;
   color: inherit;

--- a/visualizer/flame-graph.css
+++ b/visualizer/flame-graph.css
@@ -16,6 +16,9 @@ chart {
 chart > div {
   height: 100%;
 }
+#flame-main .flamegraph-outer {
+  border-top: 1px solid var(--light-glare);
+}
 
 /* node-highlighter */
 .node-highlighter {
@@ -45,10 +48,10 @@ chart > div {
 
 .node-highlighter .down-arrow {
   border-color: transparent;
-  border-top-color: var(--overlay-bg-color);
+  border-top-color: var(--banner-bg-color);
   border-style: solid;
   border-width: 10px;
-  filter: drop-shadow(0px 1px 0px rgba(255, 255, 255, 0.5));
+  filter: drop-shadow(0px 1px 0px var(--light-glare));
   margin:0 0 -8px;
   flex-shrink: 0;
 }
@@ -93,7 +96,7 @@ chart > div {
 
 .fg-tooltip-actions button {
   align-items: center;
-  background-color: transparent;
+  background-color: var(--opposite-translucent);
   border-radius: 0;
   border: none;
   color: inherit;

--- a/visualizer/info-box.css
+++ b/visualizer/info-box.css
@@ -1,5 +1,5 @@
 #info-box .frame-info {
-  background-color: var(--banner-bg-color);
+  background-color: var(--opposite-translucent);
   color: var(--grey-highlight);
   display: flex;
   font-size: var(--normal-text-size);

--- a/visualizer/info-box.css
+++ b/visualizer/info-box.css
@@ -1,5 +1,5 @@
 #info-box .frame-info {
-  background-color: var(--opposite-translucent);
+  background-color: rgba(var(--opposite-color-val), 0.5);
   color: var(--grey-highlight);
   display: flex;
   font-size: var(--normal-text-size);

--- a/visualizer/key.css
+++ b/visualizer/key.css
@@ -33,7 +33,7 @@
 
 #key-panel .key-title {
   flex-grow: 1;
-  color: var(--primary-grey);
+  color: var(--grey-highlight);
 }
 
 #key-panel .key-title em {

--- a/visualizer/options-menu.css
+++ b/visualizer/options-menu.css
@@ -1,12 +1,11 @@
 #options-menu .options {
   right: 0;
-  padding: 8px 0;
   width: 100%;
   font-size: var(--small-text-size);
   position: absolute;
   z-index: 1;
-  background-color: var(--options-menu-bg-color);
-  margin-top: 6px;
+  background-color: var(--opposite-translucent);
+  margin-top: 8px;
 }
 
 #options-menu .options .children-toggle-btn{
@@ -34,9 +33,9 @@
 
 #options-menu .options .section {
   border: none;
-  padding: 0;
-  margin: 0 0 10px 0;
+  padding: 8px 0 0 0;
   position: relative; /* forces this to show on _top_ of the .options element, else it's not clickable */
+  background-color: var(--opposite-translucent);
 }
 
 #options-menu .options .section:last-child {
@@ -93,13 +92,9 @@
 
 #options-menu .options label:hover {
   white-space: normal;
-  /* background of options area mixed with:
-   *   rgba(255, 255, 255, 0.06)
-   * included as a constant value so this colour
-   * obscures the lower items that it overflows on hover. */
-  background-color: rgb(66, 69, 81);
   height: auto;
   z-index: 3;
+  background: var(--opposite-contrast);
 }
 
 #options-menu .options label {

--- a/visualizer/options-menu.css
+++ b/visualizer/options-menu.css
@@ -4,7 +4,7 @@
   font-size: var(--small-text-size);
   position: absolute;
   z-index: 1;
-  background-color: var(--opposite-translucent);
+  background-color: rgba(var(--opposite-color-val), 0.85);
   margin-top: 8px;
 }
 
@@ -35,7 +35,6 @@
   border: none;
   padding: 8px 0 0 0;
   position: relative; /* forces this to show on _top_ of the .options element, else it's not clickable */
-  background-color: var(--opposite-translucent);
 }
 
 #options-menu .options .section:last-child {
@@ -211,7 +210,7 @@
   cursor: pointer;
   display: flex;
   justify-content: space-between;
-  font-size: var(--small-text-size);  
+  font-size: var(--small-text-size);
   font-weight: bold;
   padding: 2px 6px;
   width: 100%;

--- a/visualizer/selection-controls.css
+++ b/visualizer/selection-controls.css
@@ -1,18 +1,16 @@
 #selection-controls {
   display: flex;
-  padding: 6px;
-  background-color: var(--banner-bg-color);
 }
 
 #selection-controls .hotness-selector:disabled {
   color: var(--primary-grey);
   cursor: auto;
-  opacity: 0.5;
+  background: var(--opposite-translucent);
 }
 
 #selection-controls .hotness-selector {
   padding: 4px 8px;
-  margin: 0px 2px;
+  margin-right: 4px;
   background-color: var(--opposite-contrast);
   color: var(--max-contrast);
   border: none;
@@ -60,13 +58,13 @@
 @media screen and (min-width: 530px) {
   .visible-from-bp-1 {
     display: initial;
-  } 
+  }
 }
 
 @media screen and (min-width: 680px) {
   .visible-from-bp-2 {
     display: initial;
-  } 
+  }
 }
 
 /* presentation mode */

--- a/visualizer/selection-controls.css
+++ b/visualizer/selection-controls.css
@@ -5,7 +5,7 @@
 #selection-controls .hotness-selector:disabled {
   color: var(--primary-grey);
   cursor: auto;
-  background: var(--opposite-translucent);
+  background: rgba(var(--opposite-color-val), 0.5);
 }
 
 #selection-controls .hotness-selector {

--- a/visualizer/stack-bar.css
+++ b/visualizer/stack-bar.css
@@ -30,12 +30,13 @@
   height: 18px;
   align-items: center;
   background: var(--main-bg-color);
+  border-bottom: 1px solid var(--light-glare);
 }
 
 
 #stack-bar .pointer {
   border-color: transparent;
-  border-bottom-color: var(--overlay-bg-color);
+  border-bottom-color: var(--banner-bg-color);
   border-style: solid;
   border-width: 10px;
   bottom: 0px;
@@ -44,7 +45,7 @@
   pointer-events: none;
   position: absolute;
   transition: transform .5s cubic-bezier(0.65, 0.05, 0.36, 1);
-  filter: drop-shadow(0px -1px 0px rgba(255, 255, 255, 0.5));
+  filter: drop-shadow(0px -1px 0px var(--light-glare));
 }
 
 

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -90,6 +90,7 @@ html.light {
 html.presentation-mode {
   --banner-bg-color: rgb(120, 122, 128);
   --main-bg-color: rgb(76, 78, 84);
+  --grey-highlight: rgb(255, 255, 255);
 
   --area-color-deps: rgb(145, 210, 255);
   --area-color-core: rgb(160, 155, 215);

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -33,11 +33,11 @@ html {
   --main-bg-color-val: 27, 30, 39;
   --max-contrast: rgb(255, 255, 255);
   --opposite-contrast: rgb(0, 0, 0);
-  --light-glare: rgba(255, 255, 255, 0.1);
+  --opposite-translucent: rgba(0, 0, 0, 0.5);
+  --light-glare: rgba(255, 255, 255, 0.3);
 
   --main-bg-color: rgb(var(--main-bg-color-val));
   --main-bg-translucent: rgba(var(--main-bg-color-val), 0.94);
-  --overlay-bg-color: #41444f;
 
   --banner-bg-color-val: 50, 53, 61;
   --banner-bg-color: rgb(var(--banner-bg-color-val));
@@ -88,8 +88,7 @@ html.light {
 /* Overrides for Presentation mode */
 /* just a poc for now... */
 html.presentation-mode {
-  --banner-bg-color: #14161d;
-  --overlay-bg-color: #14161d;
+  --banner-bg-color: rgb(20, 22, 29);
   --main-bg-color: rgb(47, 53, 66);
   --options-menu-bg-color: #14161d;
 
@@ -204,7 +203,6 @@ html * {
   flex-shrink: 1;
   overflow: auto;
   position: relative;
-  border-top: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 .scroll-container::-webkit-scrollbar {

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -88,9 +88,8 @@ html.light {
 /* Overrides for Presentation mode */
 /* just a poc for now... */
 html.presentation-mode {
-  --banner-bg-color: rgb(20, 22, 29);
-  --main-bg-color: rgb(47, 53, 66);
-  --options-menu-bg-color: #14161d;
+  --banner-bg-color: rgb(120, 122, 128);
+  --main-bg-color: rgb(76, 78, 84);
 
   --area-color-deps: rgb(145, 210, 255);
   --area-color-core: rgb(160, 155, 215);

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -32,8 +32,8 @@ html {
 
   --main-bg-color-val: 27, 30, 39;
   --max-contrast: rgb(255, 255, 255);
-  --opposite-contrast: rgb(0, 0, 0);
-  --opposite-translucent: rgba(0, 0, 0, 0.5);
+  --opposite-contrast: rgb(var(--opposite-color-val));
+  --opposite-color-val: 0, 0, 0;
   --light-glare: rgba(255, 255, 255, 0.3);
 
   --main-bg-color: rgb(var(--main-bg-color-val));

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -93,8 +93,8 @@ html.presentation-mode {
   --main-bg-color: rgb(47, 53, 66);
   --options-menu-bg-color: #14161d;
 
-  --area-color-deps: rgb(94, 191, 247);  
-  --area-color-core: rgb(153, 187, 159);
+  --area-color-deps: rgb(145, 210, 255);
+  --area-color-core: rgb(160, 155, 215);
 }
 
 /* Main layout */

--- a/visualizer/toolbar.css
+++ b/visualizer/toolbar.css
@@ -1,5 +1,5 @@
 #toolbar {
-  background-color: var(--overlay-bg-color);
+  background-color: var(--banner-bg-color);
   z-index: 5;
   position: relative;
 }
@@ -21,10 +21,8 @@
 }
 
 #toolbar-side-panel {
-  padding: 6px;
   flex-grow: 0;
   display: flex;
-  background-color: var(--banner-bg-color);
   position: relative;
   min-width: 25em;
 }
@@ -45,7 +43,7 @@
   }
   #toolbar-top-panel {
     justify-content: space-between;
-  } 
+  }
 }
 
 @media screen and (min-width: 720px) {


### PR DESCRIPTION
This PR will be rebased when https://github.com/nearform/node-clinic-flame/pull/30 is merged, then after review changes etc, the plan is to release it in the same release. Current state is merged against latest https://github.com/nearform/node-clinic-flame/pull/30 and latest master (so this includes the bug fix in 3.2.1 / https://github.com/nearform/node-clinic-flame/pull/42 )

It does a few things:

 - Makes presentation mode clearer on a projector in extreme conditions. Tested with a projector from further than the recommended distance in a room with bright daylight, see https://github.com/nearform/node-clinic-flame/pull/30#issuecomment-439799245 for photos and a screenshot
 - Simplifies the general design a little outside of presentation mode:
   - Dropping the grey borders around the buttons in the info box
   - Making the options menu background black so the text contrast is stronger and it's more consistent between normal and presentation mode:

![image](https://user-images.githubusercontent.com/29628323/48843870-485e1900-ed90-11e8-84bc-fe038c4a28d8.png)

   - Giving tooltip buttons slightly sharper highlighting on hover - a grey border normally, a strong white border around the hoverred button, and an opaque background on the hoverred button so it is slightly sharper and easier to read:

![image](https://user-images.githubusercontent.com/29628323/48843954-86f3d380-ed90-11e8-8c25-82f22a7aeddf.png)

There's also a general tidy up of the CSS, replacing most of the hard-coded RGB values with CSS variables (will save a lot of hassle when we add light / printer-friendly view mode), and reducing the number of CSS variables.