### PR TITLE
Fix/tooltip fixes

### DIFF
--- a/visualizer/stack-bar.js
+++ b/visualizer/stack-bar.js
@@ -45,12 +45,6 @@ class StackBar extends HtmlContent {
         ui.highlightNode(nodeElem.d)
 
         const wrapperRect = this.d3StacksWrapper.node().getBoundingClientRect()
-        const targetRect = {
-          x: d3.event.offsetX - 10,
-          width: wrapperRect.width * nodeElem.width,
-          y: wrapperRect.y,
-          height: wrapperRect.height
-        }
 
         if (!nodeData) {
           this.tooltip.hide()
@@ -60,8 +54,8 @@ class StackBar extends HtmlContent {
         this.tooltipHtmlContent.setNodeData(nodeData)
         this.tooltip.show({
           msg: this.tooltipHtmlContent.getTooltipD3().node(),
-          pointerCoords: { x: d3.event.offsetX - 10, y: d3.event.offsetY },
-          targetRect,
+          pointerCoords: { x: d3.event.offsetX, y: d3.event.offsetY },
+          targetRect: wrapperRect,
           wrapperNode: this.d3StacksWrapper.node()
         })
       })

--- a/visualizer/tooltip.js
+++ b/visualizer/tooltip.js
@@ -87,7 +87,13 @@ class Tooltip extends HtmlContent {
     this.d3TooltipInner.classed('top bottom', false)
     this.d3TooltipInner.classed(verticalAlign, true)
 
-    let innerRect = Object.assign({ }, targetRect || d3TargetElement.node().getBoundingClientRect())
+    const obj = targetRect || d3TargetElement.node().getBoundingClientRect()
+    let innerRect = {
+      x: obj.x,
+      y: obj.y,
+      width: obj.width,
+      height: obj.height
+    }
 
     if (offset) {
       innerRect.x += offset.x || 0

--- a/visualizer/tooltip.js
+++ b/visualizer/tooltip.js
@@ -87,19 +87,18 @@ class Tooltip extends HtmlContent {
     this.d3TooltipInner.classed('top bottom', false)
     this.d3TooltipInner.classed(verticalAlign, true)
 
-    const obj = targetRect || d3TargetElement.node().getBoundingClientRect()
-    let innerRect = {
-      x: obj.x,
-      y: obj.y,
-      width: obj.width,
-      height: obj.height
-    }
+    let {
+      x,
+      y,
+      width,
+      height
+    } = targetRect || d3TargetElement.node().getBoundingClientRect()
 
     if (offset) {
-      innerRect.x += offset.x || 0
-      innerRect.y += offset.y || 0
-      innerRect.width += offset.width || 0
-      innerRect.height += offset.height || 0
+      x += offset.x || 0
+      y += offset.y || 0
+      width += offset.width || 0
+      height += offset.height || 0
     }
 
     if (typeof (msg) === 'string') {
@@ -111,12 +110,12 @@ class Tooltip extends HtmlContent {
 
     clearTimeout(this.tooltipHandler)
 
-    let ttLeft = innerRect.x + innerRect.width / 2
-    let ttTop = innerRect.y + (verticalAlign === 'bottom' ? innerRect.height : 0)
+    let ttLeft = x + width / 2
+    let ttTop = y + (verticalAlign === 'bottom' ? height : 0)
 
     if (pointerCoords) {
       // centering on the mouse pointer horizontally
-      ttLeft = innerRect.x + pointerCoords.x
+      ttLeft = x + pointerCoords.x
     }
 
     this.d3Tooltip
@@ -132,11 +131,11 @@ class Tooltip extends HtmlContent {
 
     // positioning the tooltip content
     // making sure that it doesn't go over the frame right edge
-    const alignRight = ttLeft + ttWidth - (innerRect.x + innerRect.width)
+    const alignRight = ttLeft + ttWidth - (x + width)
     let deltaX = Math.max(alignRight, ttWidth / 2)
 
     // then checking it doesn't overflow the frame left edge
-    deltaX = (ttLeft - deltaX < innerRect.x) ? ttLeft - innerRect.x : deltaX
+    deltaX = (ttLeft - deltaX < x) ? ttLeft - x : deltaX
 
     // then checking the outer element right edge
     if (outerRect) {


### PR DESCRIPTION
This PR fixes the [bug noted here](https://github.com/nearform/node-clinic-flame/issues/47)
The issue was caused by the incorrect use of `Object.assign`, [as explained here](https://stackoverflow.com/questions/42713229/why-are-properties-of-this-object-domrect-inaccessible-to-standard-javascript)

This PR also fixes the tooltip positioning issue we had on the `Stack-bar` (mainly when hovering over very large frames, see screenshot) 
![screenshot 2018-11-22 at 12 20 11](https://user-images.githubusercontent.com/1298616/48899867-13fe6180-ee51-11e8-9987-9f0d75da3bc2.png)

