### PR TITLE
Fix errors if user hides all nodes 

### DIFF
--- a/visualizer/data-tree.js
+++ b/visualizer/data-tree.js
@@ -2,6 +2,7 @@
 
 const shared = require('../shared.js')
 const flameGradient = require('flame-gradient')
+const getNoDataNode = require('./no-data-node.js')
 const d3 = require('./d3.js')
 
 class DataTree {
@@ -112,11 +113,12 @@ class DataTree {
 
   getFlattenedSorted (sorter, arr) {
     const filtered = arr.filter(node => !this.isNodeExcluded(node))
-    return filtered.sort(sorter)
+    if (filtered.length) return filtered.sort(sorter)
+    return [ getNoDataNode() ]
   }
 
   getHeatColor (node, arr = this.flatByHottest) {
-    if (!node || this.isNodeExcluded(node)) return flameGradient(0)
+    if (!node || this.isNodeExcluded(node) || this.mean === 0) return flameGradient(0)
 
     const pivotPoint = this.mean / (this.mean + this.maxRootAboveMean + this.maxRootBelowMean)
 

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -222,7 +222,7 @@ class FlameGraph extends HtmlContent {
       // Show tooltip and highlight box for zoomed node after zoom completes
       if (this.ui.zoomedNode && this.ui.zoomedNode.id !== 0) {
         if (this.tooltip) {
-          const rect = this.flameGraph.getNodeRect(this.ui.zoomedNode)
+          const rect = this.getNodeRect(this.ui.zoomedNode)
           this.tooltip.show({
             nodeData: this.ui.zoomedNode,
             rect,
@@ -253,6 +253,10 @@ class FlameGraph extends HtmlContent {
   }
 
   getNodeRect (node) {
+    // Get an override for non-standard nodes e.g. from no-data-node.js
+    if (node.getNodeRect) return node.getNodeRect()
+
+    // Get a { x, y, width, height } object from d3-fg for regular nodes
     return this.flameGraph.getNodeRect(node)
   }
 
@@ -263,7 +267,7 @@ class FlameGraph extends HtmlContent {
       return
     }
 
-    const rect = this.flameGraph.getNodeRect(this.hoveredNodeData)
+    const rect = this.getNodeRect(this.hoveredNodeData)
     if (rect) {
       this.d3Highlighter.classed('show', true)
       this.applyRectToDiv(this.d3Highlighter, rect, true)
@@ -283,7 +287,8 @@ class FlameGraph extends HtmlContent {
     this.d3SelectionMarker.classed('hidden', !node)
 
     if (node) {
-      const rect = this.flameGraph.getNodeRect(node)
+      const rect = this.getNodeRect(node)
+
       this.applyRectToDiv(this.d3SelectionMarker, Object.assign({}, {
         // Ensure marker is visible on tiny frames
         width: rect.width < 2 ? 2 : rect.width
@@ -295,7 +300,7 @@ class FlameGraph extends HtmlContent {
     this.d3ZoomMarker.classed('hidden', !node)
 
     if (node) {
-      const rect = this.flameGraph.getNodeRect(node)
+      const rect = this.getNodeRect(node)
       this.applyRectToDiv(this.d3ZoomMarker, {
         x: rect.x,
         y: rect.y + rect.height * 4,

--- a/visualizer/info-box.js
+++ b/visualizer/info-box.js
@@ -1,13 +1,19 @@
 'use strict'
 const HtmlContent = require('./html-content.js')
+const getNoDataNode = require('./no-data-node.js')
 
 class InfoBox extends HtmlContent {
   constructor (parentContent, contentProperties = {}) {
     super(parentContent, contentProperties)
 
-    this.functionText = 'Loading…'
-    this.pathText = '[file location]'
-    this.areaText = '[node.js module]'
+    const {
+      functionName,
+      fileName
+    } = getNoDataNode()
+
+    this.functionText = functionName
+    this.pathText = fileName
+    this.areaText = 'Processing data...'
   }
 
   initializeElements () {
@@ -43,7 +49,9 @@ class InfoBox extends HtmlContent {
 
     const typeLabel = node.category === 'core' ? '' : ` (${this.ui.getLabelFromKey(`${node.category}:${node.type}`, true)})`
     const categoryLabel = this.ui.getLabelFromKey(node.category, true)
-    this.areaText = `In ${categoryLabel}${typeLabel}`
+
+    // e.g. The no-data-node has an .areaText containing a custom message
+    this.areaText = node.areaText || `In ${categoryLabel}${typeLabel}`
 
     if (node.isInit) this.areaText += '. In initialization process'
     if (node.isInlinable) this.areaText += '. Inlinable'

--- a/visualizer/main.js
+++ b/visualizer/main.js
@@ -13,7 +13,7 @@ ui.setData(dataTree)
 // And only if no node was selected during initialization by some other means
 // (eg from parsing the history hash).
 ui.draw()
-if (ui.selectedNode === null) {
+if (!ui.selectedNode || ui.selectedNode.category === 'none') {
   ui.selectHottestNode()
 }
 

--- a/visualizer/no-data-node.js
+++ b/visualizer/no-data-node.js
@@ -1,0 +1,32 @@
+'use strict'
+
+// Recreate the object every time it is needed so the caller
+// can change properties without mutating the original.
+function getNoDataNode () {
+  return {
+    category: 'none', // Used to distinguish fake nodes like this from real ones
+    children: [],
+    functionName: 'No data.',
+    fileName: 'Nothing to show currently.',
+    id: null, // Don't show any id in the url hash
+    name: '',
+    onStackTop: {
+      asViewed: 0,
+      base: 0,
+      rootFromMean: 0
+    },
+    type: 'none',
+
+    areaText: 'No frames are visible', // Trailing '.' is added in info-box.js
+    getNodeRect: function () {
+      return {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0
+      }
+    }
+  }
+}
+
+module.exports = getNoDataNode

--- a/visualizer/no-data-node.js
+++ b/visualizer/no-data-node.js
@@ -15,7 +15,7 @@ function getNoDataNode () {
       base: 0,
       rootFromMean: 0
     },
-    type: 'none',
+    type: 'no-data', // Used for this node specifically, indicating no visible data
 
     areaText: 'No frames are visible', // Trailing '.' is added in info-box.js
     getNodeRect: function () {

--- a/visualizer/selection-controls.js
+++ b/visualizer/selection-controls.js
@@ -50,16 +50,18 @@ class SelectionControls extends HtmlContent {
   draw () {
     super.draw()
 
-    this.d3FramesCount.html(`<span class="visible-from-bp-1">of ${this.framesCount}</span>`)
-    this.d3SelectNumber.property('value', this.rankNumber + 1)
+    const noNodes = this.ui.selectedNode.type === 'no-data'
+
+    this.d3FramesCount.html(`<span class="visible-from-bp-1">of ${noNodes ? 0 : this.framesCount}</span>`)
+    this.d3SelectNumber.property('value', noNodes ? 0 : this.rankNumber + 1)
 
     const isHottest = this.rankNumber === 0
-    this.d3SelectHotter.attr('disabled', isHottest || null)
-    this.d3SelectHottest.attr('disabled', isHottest || null)
+    this.d3SelectHotter.attr('disabled', noNodes || isHottest || null)
+    this.d3SelectHottest.attr('disabled', noNodes || isHottest || null)
 
     const isColdest = this.rankNumber === this.framesCount - 1
-    this.d3SelectCooler.attr('disabled', isColdest || null)
-    this.d3SelectColdest.attr('disabled', isColdest || null)
+    this.d3SelectCooler.attr('disabled', noNodes || isColdest || null)
+    this.d3SelectColdest.attr('disabled', noNodes || isColdest || null)
   }
 
   initializeElements () {

--- a/visualizer/selection-controls.js
+++ b/visualizer/selection-controls.js
@@ -50,7 +50,7 @@ class SelectionControls extends HtmlContent {
   draw () {
     super.draw()
 
-    const noNodes = this.ui.selectedNode.type === 'no-data'
+    const noNodes = this.ui.selectedNode && this.ui.selectedNode.type === 'no-data'
 
     this.d3FramesCount.html(`<span class="visible-from-bp-1">of ${noNodes ? 0 : this.framesCount}</span>`)
     this.d3SelectNumber.property('value', noNodes ? 0 : this.rankNumber + 1)

--- a/visualizer/stack-bar.js
+++ b/visualizer/stack-bar.js
@@ -45,6 +45,8 @@ class StackBar extends HtmlContent {
         clearTimeout(this.highlightedNodeTimeoutHandler)
 
         const nodeElem = this.getNodeAtX(d3.event.offsetX)
+        if (!nodeElem) return
+
         const nodeData = nodeElem.d
         ui.highlightNode(nodeElem.d)
 
@@ -72,6 +74,8 @@ class StackBar extends HtmlContent {
       })
       .on('click', () => {
         const nodeElem = this.getNodeAtX(d3.event.offsetX)
+        if (!nodeElem) return
+
         const nodeData = nodeElem.d
         if (nodeData) {
           this.ui.highlightNode(nodeData)
@@ -80,6 +84,8 @@ class StackBar extends HtmlContent {
       })
       .on('dblclick', () => {
         const nodeElem = this.getNodeAtX(d3.event.offsetX)
+        if (!nodeElem) return
+
         const nodeData = nodeElem.d
         if (nodeData) {
           this.ui.zoomNode(nodeData)

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -415,9 +415,9 @@ class Ui extends events.EventEmitter {
   updateExclusions ({ initial, pushState = true, selectedNodeId, zoomedNodeId } = {}) {
     this.dataTree.update(initial)
 
-    const noVisibleSelectedNode = this.dataTree.isNodeExcluded(this.selectedNode) || this.selectedNode.category === 'none'
+    const selectedNodeNotShown = this.selectedNode && (this.dataTree.isNodeExcluded(this.selectedNode) || this.selectedNode.category === 'none')
 
-    if (!initial && !selectedNodeId && this.selectedNode && noVisibleSelectedNode) {
+    if (!initial && !selectedNodeId && selectedNodeNotShown) {
       this.selectHottestNode()
     }
 

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -7,6 +7,7 @@ const DataTree = require('./data-tree.js')
 const History = require('./history.js')
 
 const TooltipHtmlContent = require('./flame-graph-tooltip-content')
+const getNoDataNode = require('./no-data-node.js')
 
 class Ui extends events.EventEmitter {
   constructor (wrapperSelector) {
@@ -16,7 +17,9 @@ class Ui extends events.EventEmitter {
 
     this.dataTree = null
     this.highlightedNode = null
-    this.selectedNode = null
+
+    this.selectedNode = getNoDataNode()
+
     this.zoomedNode = null
     this.changedExclusions = {
       toHide: new Set(),
@@ -125,10 +128,10 @@ class Ui extends events.EventEmitter {
 
   selectHottestNode (opts) {
     const node = this.dataTree.getFrameByRank(0)
-    const nodeInvalidMessage = ' node selected in selectHottestNode'
+    if (!node) return getNoDataNode()
 
     // Prevent infinite loop if some future bug allows an invalid node to be returned here
-    if (!node) throw new Error('No' + nodeInvalidMessage)
+    const nodeInvalidMessage = ' node selected in selectHottestNode'
     if (node.id === 0) throw new Error('Root' + nodeInvalidMessage)
     if (this.dataTree.isNodeExcluded(node)) throw new Error('Excluded' + nodeInvalidMessage)
 
@@ -297,7 +300,7 @@ class Ui extends events.EventEmitter {
       }
 
       let scrollAmount = scrollContainer.scrollHeight
-      if (this.selectedNode) {
+      if (this.selectedNode && this.selectedNode.category !== 'none') {
         const viewportHeight = scrollContainer.clientHeight
         const rect = this.flameWrapper.getNodeRect(this.selectedNode)
 
@@ -412,7 +415,9 @@ class Ui extends events.EventEmitter {
   updateExclusions ({ initial, pushState = true, selectedNodeId, zoomedNodeId } = {}) {
     this.dataTree.update(initial)
 
-    if (!selectedNodeId && this.selectedNode && this.dataTree.isNodeExcluded(this.selectedNode)) {
+    const noVisibleSelectedNode = this.dataTree.isNodeExcluded(this.selectedNode) || this.selectedNode.category === 'none'
+
+    if (!initial && !selectedNodeId && this.selectedNode && noVisibleSelectedNode) {
       this.selectHottestNode()
     }
 


### PR DESCRIPTION
Fixes https://github.com/nearform/node-clinic-flame/issues/16

Instead of hitting an error when a user hides all nodes, they get this view:

![image](https://user-images.githubusercontent.com/29628323/49226209-dadc6900-f3dd-11e8-86e0-243ec4a0f6f7.png)

This fixes it by using a dummy node when the visible dataset is empty. This avoids the problem described by @goto-bus-stop in https://github.com/nearform/node-clinic-flame/issues/16 of many parts of the code expecting data and means we don't have to pepper the code with, for example,  `if (this.ui.dataTree.flatByHottest.length)` checks. 

There's always a selected node and at least one visible node in the data for everything to use: it just might be a 0-value dummy, identifiable by `type === 'no-data'` or `category === 'none'` (if we in future needed other types of dummy node), with `fileName` and `functionName` properties that put a message for the user in the info bar.