### PR TITLE
Unescape escaped backslashes (\\u005c)

### DIFF
--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -9,7 +9,8 @@ class FrameNode {
     this.id = null
 
     /* istanbul ignore next: must be a string; can be null but can't replicate in tests */
-    this.name = data.name || ''
+    // If backslashes have been hard-escaped as their unicode escape char, swap them back in
+    this.name = data.name.replace(/\\u005c/g, '\\') || ''
 
     this.onStack = data.value
     this.onStackTop = { base: data.top }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "0x": "^4.6.0",
+    "0x": "^4.7.1",
     "@nearform/clinic-common": "^1.1.0",
     "brfs": "^2.0.1",
     "browserify": "^16.2.2",


### PR DESCRIPTION
Fixes https://github.com/nearform/node-clinic-flame/issues/58 ~but we should double-check again after that 0x PR https://github.com/davidmarkclements/0x/pull/203 lands.~ landed, released as 4.7.1, included in this PR.

Before (Node 10.13.0 profile generated on Windows):

![image](https://user-images.githubusercontent.com/29628323/49360607-9bf62e00-f6d1-11e8-8aea-201aed942a70.png)

After:

![image](https://user-images.githubusercontent.com/29628323/49360632-aa444a00-f6d1-11e8-9b4a-fffef09b7ad2.png)

Both before and after look pretty much the same with and without https://github.com/davidmarkclements/0x/pull/203  branch of 0x, and same on Node 8 too. 