### PR TITLE
Raise test timeout limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "visualize-watch": "node debug/visualize-watch.js",
     "visualize-all": "node debug/visualize-all.js",
-    "test": "npm run lint && tap --100 test/*.test.js",
+    "test": "npm run lint && tap --timeout=50 --100 test/*.test.js",
     "ci-lint": "npm run lint",
-    "ci-test-cov": "tap --100 test/*.test.js",
-    "ci-test-no-cov": "tap test/*.test.js",
+    "ci-test-cov": "tap --100 --timeout=50 test/*.test.js",
+    "ci-test-no-cov": "tap --timeout=40 test/*.test.js",
     "lint": "standard --fix | snazzy"
   },
   "author": "",


### PR DESCRIPTION
We don't know exactly why we're failing on CITGM https://github.com/nearform/node-clinic-flame/issues/55 - but we've got some tests which can take ~25 seconds to run locally and on our CI, and given that Doctor has a problem with tests passing locally and on our CI but timing out on CITGM, it stands to reason that Flame is at risk of the same thing.

Smaller increase than the equivalent Doctor PR https://github.com/nearform/node-clinic-doctor/pull/197 because it's not explictly confirmed that we are timing out. As with that PR, a) higher limit when coverage is enabled, b) we should also try to make the slow tests faster.