### PR TITLE
Collect dependencies as separate code areas.

### DIFF
--- a/analysis/code-areas.js
+++ b/analysis/code-areas.js
@@ -1,3 +1,5 @@
+'use strict'
+
 // Turn a Set of code area names into a sorted list of code area objects.
 // This sorts by name right now, just to have a consistent output,
 // but could use eg. the heat of the area in the future.

--- a/analysis/code-areas.js
+++ b/analysis/code-areas.js
@@ -1,0 +1,60 @@
+// Turn a Set of code area names into a sorted list of code area objects.
+// This sorts by name right now, just to have a consistent output,
+// but could use eg. the heat of the area in the future.
+function toCodeAreaChildren (set) {
+  return Array.from(set, (id) => {
+    return { id }
+  }).sort(sorter)
+
+  function sorter (a, b) {
+    return a.id.localeCompare(b.id)
+  }
+}
+
+function collectCodeAreas (trees) {
+  const appCodeAreas = new Set()
+  const depCodeAreas = new Set()
+
+  function collect (node) {
+    if (node.category === 'deps') {
+      depCodeAreas.add(node.type)
+    }
+  }
+
+  // Make sure we have all code areas that are used, by collecting from both merged and unmerged trees.
+  trees.merged.walk(collect)
+  trees.unmerged.walk(collect)
+
+  const codeAreas = [
+    { id: 'app',
+      children: toCodeAreaChildren(appCodeAreas),
+      // Only show the "show more" button if there's many code areas
+      // at 2 or less the button will take at least as much space as the area labels anyway
+      childrenVisibilityToggle: appCodeAreas.size > 2 },
+    { id: 'deps',
+      children: toCodeAreaChildren(depCodeAreas),
+      childrenVisibilityToggle: depCodeAreas.size > 2 },
+    { id: 'core' },
+    { id: 'all-v8',
+      children: [
+        { id: 'v8' },
+        { id: 'native' },
+        { id: 'cpp' },
+        { id: 'regexp' }
+      ],
+      childrenVisibilityToggle: true }
+  ]
+
+  codeAreas.forEach(area => {
+    area.excludeKey = area.id
+    if (area.children) {
+      area.children.forEach(childArea => {
+        childArea.excludeKey = `${area.id}:${childArea.id}`
+      })
+    }
+  })
+
+  return codeAreas
+}
+
+module.exports = collectCodeAreas

--- a/analysis/index.js
+++ b/analysis/index.js
@@ -32,8 +32,8 @@ async function analyse (paths) {
       node.categorise(systemInfo, appName)
       node.format(systemInfo)
 
-      if (node.type === 'deps') {
-        depCodeAreas.add(`deps:${node.typeTEMP}`)
+      if (node.category === 'deps') {
+        depCodeAreas.add(`deps:${node.type}`)
       }
     }),
     (tree) => setStackTop(tree, defaultExclude)

--- a/analysis/index.js
+++ b/analysis/index.js
@@ -12,6 +12,14 @@ const {
 
 const readFile = promisify(fs.readFile)
 
+// TODO Remove this function when the UI side of dependency code areas
+// is implemented.
+function removeDependencyAreasFromCodeAreas (codeAreas) {
+  const depArea = codeAreas.find((area) => area.id === 'deps')
+  delete depArea.children
+  delete depArea.childrenVisibilityToggle
+}
+
 async function analyse (paths) {
   const [ systemInfo, ticks, inlined ] = await Promise.all([
     readFile(paths['/systeminfo'], 'utf8').then(JSON.parse),
@@ -41,20 +49,11 @@ async function analyse (paths) {
     step(unmerged)
   })
 
-  // Turn a Set of code area names into a sorted list of code area objects.
-  // This sorts by name right now, just to have a consistent output,
-  // but could use eg. the heat of the area in the future.
-  function toCodeAreaChildren (set) {
-    return Array.from(set, (id) => {
-      return { id }
-    }).sort(sorter)
-
-    function sorter (a, b) {
-      return a.id.localeCompare(b.id)
-    }
-  }
-
   const codeAreas = collectCodeAreas({ merged, unmerged })
+
+  // TODO Remove this TEMPORARY call when UI side of code area collection
+  // is implemented
+  removeDependencyAreasFromCodeAreas(codeAreas)
 
   return {
     appName,

--- a/analysis/index.js
+++ b/analysis/index.js
@@ -33,7 +33,7 @@ async function analyse (paths) {
       node.format(systemInfo)
 
       if (node.category === 'deps') {
-        depCodeAreas.add(`deps:${node.type}`)
+        depCodeAreas.add(node.type)
       }
     }),
     (tree) => setStackTop(tree, defaultExclude)

--- a/test/analysis-dependencies.test.js
+++ b/test/analysis-dependencies.test.js
@@ -1,0 +1,80 @@
+const { test } = require('tap')
+const FrameNode = require('../analysis/frame-node.js')
+const collectCodeAreas = require('../analysis/code-areas.js')
+
+const linux = {
+  mainDirectory: '/home/clinic',
+  pathSeparator: '/',
+  nodeVersions: { node: '11.3.0' }
+}
+
+function byProps (properties, systemInfo, appName = 'some-app') {
+  const tree = new FrameNode(properties)
+  tree.walk((node) => {
+    node.categorise(systemInfo, appName)
+    node.format(systemInfo)
+  })
+  return tree
+}
+
+test('analysis - code areas - contains basic areas', (t) => {
+  const merged = byProps({ name: 'fn /home/clinic/code/app.js:1:8' }, linux)
+  const codeAreas = collectCodeAreas({ merged, unmerged: merged })
+  t.ok(codeAreas.some((area) => area.id === 'app'))
+  t.ok(codeAreas.some((area) => area.id === 'deps'))
+  t.ok(codeAreas.some((area) => area.id === 'all-v8'))
+  t.end()
+})
+
+test('analysis - code areas - identifies dependency areas', (t) => {
+  const merged = byProps({
+    name: 'fn /home/clinic/code/node_modules/fastify/index.js:1:8',
+    children: [{
+      name: 'fn2 /home/clinic/code/node_modules/lol/index.js:1:8'
+    }]
+  }, linux)
+  const codeAreas = collectCodeAreas({ merged, unmerged: merged })
+  const depArea = codeAreas.find((area) => area.id === 'deps')
+
+  t.ok(Array.isArray(depArea.children))
+  t.equal(depArea.children.length, 2)
+  const fastifyArea = depArea.children[0]
+  const lolArea = depArea.children[1]
+  t.equal(fastifyArea.id, 'fastify')
+  t.equal(fastifyArea.excludeKey, 'deps:fastify')
+  t.equal(lolArea.id, 'lol')
+  t.equal(lolArea.excludeKey, 'deps:lol')
+  // TODO maybe this should be shown for 2 deps?
+  // see comment in analysis/code-areas.js for current reasoning
+  t.equal(depArea.childrenVisibilityToggle, false)
+  t.end()
+})
+
+test('analysis - code areas - identifies inlined dependency areas', (t) => {
+  const merged = byProps({
+    name: 'fn /home/clinic/code/node_modules/fastify/index.js:1:8',
+    children: [{
+      name: 'fn2 /home/clinic/code/node_modules/lol/index.js:1:8'
+    }]
+  }, linux)
+  const unmerged = byProps({
+    name: 'fn /home/clinic/code/node_modules/fastify/index.js:1:8',
+    children: [{
+      name: 'inlined /home/clinic/code/node_modules/smol-function/smol-function.js:10:1',
+      children: [{
+        name: 'fn2 /home/clinic/code/node_modules/lol/index.js:1:8'
+      }]
+    }]
+  }, linux)
+
+  const codeAreas = collectCodeAreas({ merged, unmerged })
+  const depArea = codeAreas.find((area) => area.id === 'deps')
+
+  t.ok(Array.isArray(depArea.children))
+  t.equal(depArea.children.length, 3)
+  // "smol-function" sorts last alphabetically
+  const inlinedArea = depArea.children[2]
+  t.equal(inlinedArea.id, 'smol-function')
+  t.equal(inlinedArea.excludeKey, 'deps:smol-function')
+  t.end()
+})

--- a/test/analysis-dependencies.test.js
+++ b/test/analysis-dependencies.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const FrameNode = require('../analysis/frame-node.js')
 const collectCodeAreas = require('../analysis/code-areas.js')

--- a/test/visualizer-history.js
+++ b/test/visualizer-history.js
@@ -21,10 +21,20 @@ test('visualizer - history - compact exclusion set serialization', (t) => {
     h.serializeExcludes(['a', 'b'])
   }, /must be a Set/)
 
-  check(new Set(['a', 'b', 'c', 'd', 'e']), '1f') // 0b11111
-  check(new Set(['a', 'e']), '11') // 0b10001
+  check(new Set(['a', 'b', 'c', 'd', 'e']), 'f800') // 0b11111
+  check(new Set(['a', 'e']), '8800') // 0b10001
   check(new Set([]), '0') // 0b00000
-  check(new Set(['c']), '4')
+  check(new Set(['c']), '2000')
 
+  // A reasonably sized exclusion list with 20 or so dependencies
+  h.availableExclusions = 'abcdefghijklmnopqrstuvwxyz'.split('')
+  check(new Set(['a', 'r', 'm', 'q', 'z']), '8008-c040') // 0b11111
+
+  // A big app with many 100s of deps
+  h.availableExclusions = []
+  for (let i = 0; i < 1000; i++) {
+    h.availableExclusions.push(`ex${i}`)
+  }
+  check(new Set(['ex17', 'ex645', 'ex123', 'ex246', 'ex643']), '0-4000-0-0-0-0-0-10-0-0-0-0-0-0-0-200-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-1400-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0') // 0b11111
   t.end()
 })

--- a/visualizer/history.js
+++ b/visualizer/history.js
@@ -21,19 +21,21 @@ class History extends EventEmitter {
   }
 
   setData (dataTree) {
-    // TODO take this information from dataTree
-    // once analysis supports it.
+    const { codeAreas } = dataTree
+    // Manually populate special quasi-categories
     this.availableExclusions = [
-      'app',
-      'deps',
-      'core',
-      'all-v8:native',
-      'all-v8:cpp',
-      'all-v8:v8',
-      'all-v8:regexp',
       'is:init',
       'is:inlinable'
     ]
+
+    codeAreas.forEach((group) => {
+      this.availableExclusions.push(group.excludeKey)
+      if (Array.isArray(group.children)) {
+        group.children.forEach((area) => {
+          this.availableExclusions.push(area.excludeKey)
+        })
+      }
+    })
 
     if (window.location.hash) {
       this.emit('change', this.deserialize(window.location.hash.replace(/^#/, '')))
@@ -57,15 +59,29 @@ class History extends EventEmitter {
       .map((name) => exclude.has(name) ? '1' : '0')
       .join('')
 
-    return parseInt(bits, 2).toString(16)
+    // serialize in groups of 16 bits (4 hex characters)
+    const groups = []
+    const groupSize = Math.pow(2, 4)
+    for (let i = 0; i < bits.length; i += groupSize) {
+      const word = bits.slice(i, i + groupSize)
+        .padEnd(groupSize, '0')
+      groups.push(parseInt(word, 2).toString(16))
+    }
+    return groups.join('-')
   }
 
   deserializeExcludes (string) {
-    const bits = parseInt(string, 16).toString(2)
-      // The leading 0s were dropped in the parseInt(2).toString(16) serialization dance, add them back.
-      .padStart(this.availableExclusions.length, '0')
-      .split('')
-      .map((n) => n === '1')
+    const bits = []
+    const groupSize = Math.pow(2, 4)
+    const groups = string.split('-')
+    groups.forEach((group, i) => {
+      let bitString = parseInt(group, 16).toString(2)
+        // The leading 0s were dropped in the parseInt(2).toString(16) serialization dance, add them back.
+        .padStart(groupSize, '0')
+      const groupBits = bitString.split('')
+        .map((n) => n === '1')
+      bits.push(...groupBits)
+    })
 
     const exclude = new Set()
     this.availableExclusions.forEach((name, i) => {
@@ -73,7 +89,6 @@ class History extends EventEmitter {
         exclude.add(name)
       }
     })
-
     return exclude
   }
 

--- a/visualizer/history.js
+++ b/visualizer/history.js
@@ -60,9 +60,12 @@ class History extends EventEmitter {
       .join('')
 
     // serialize in groups of 16 bits (4 hex characters)
+    // this way we can have more groups than there are (reliable) bits in a JS number.
     const groups = []
     const groupSize = Math.pow(2, 4)
     for (let i = 0; i < bits.length; i += groupSize) {
+      // If there are less than 16 bits left, we add some dummy 0s at the end which
+      // are ignored by deserializeExcludes().
       const word = bits.slice(i, i + groupSize)
         .padEnd(groupSize, '0')
       groups.push(parseInt(word, 2).toString(16))
@@ -75,10 +78,11 @@ class History extends EventEmitter {
     const groupSize = Math.pow(2, 4)
     const groups = string.split('-')
     groups.forEach((group, i) => {
-      let bitString = parseInt(group, 16).toString(2)
-        // The leading 0s were dropped in the parseInt(2).toString(16) serialization dance, add them back.
+      const groupBits = parseInt(group, 16).toString(2)
+        // The leading 0s were dropped in the parseInt(2).toString(16) serialization dance
+        // in serializeExcludes(), add them back.
         .padStart(groupSize, '0')
-      const groupBits = bitString.split('')
+        .split('')
         .map((n) => n === '1')
       bits.push(...groupBits)
     })

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -383,13 +383,10 @@ class Ui extends events.EventEmitter {
       return keysToLabels[key]
     }
 
-    if (key.startsWith('deps:')) {
-      return key.slice(5)
-    }
-
     const splitKey = key.split(':')
-    if (splitKey.length > 0 && keysToLabels[splitKey[1]]) {
-      return keysToLabels[splitKey[1]]
+    if (splitKey.length > 1) {
+      const type = splitKey[1]
+      return keysToLabels[type] || type
     }
 
     return key

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -378,8 +378,21 @@ class Ui extends events.EventEmitter {
       'all-v8:cpp': 'V8 C++',
       'all-v8:regexp': 'RegExp'
     }
+
+    if (keysToLabels[key]) {
+      return keysToLabels[key]
+    }
+
+    if (key.startsWith('deps:')) {
+      return key.slice(5)
+    }
+
     const splitKey = key.split(':')
-    return keysToLabels[key] || (splitKey.length ? splitKey[1] : key)
+    if (splitKey.length > 0 && keysToLabels[splitKey[1]]) {
+      return keysToLabels[splitKey[1]]
+    }
+
+    return key
   }
 
   getDescriptionFromKey (key) {
@@ -392,7 +405,17 @@ class Ui extends events.EventEmitter {
       'all-v8:regexp': `The RegExp notation is shown as the function name. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#rx">More info</a>`
     }
 
-    return keysToDescriptions[key] || null
+    if (keysToDescriptions[key]) {
+      return keysToDescriptions[key]
+    }
+
+    if (id.startsWith('deps:')) {
+      // TODO use actual path, this is incorrect for
+      // nested dependencies
+      return `./node_modules/${id.slice(5)}`
+    }
+
+    return null
   }
 
   setCodeAreaVisibility (name, visible, manyTimes) {

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -409,10 +409,10 @@ class Ui extends events.EventEmitter {
       return keysToDescriptions[key]
     }
 
-    if (id.startsWith('deps:')) {
+    if (key.startsWith('deps:')) {
       // TODO use actual path, this is incorrect for
       // nested dependencies
-      return `./node_modules/${id.slice(5)}`
+      return `./node_modules/${key.slice(5)}`
     }
 
     return null


### PR DESCRIPTION
This still needs some styling work (a long dependency list overflows the page), probably more

Sample here:
https://upload.clinicjs.org/public/9bb3f6bd3acd7178b5cb8faa9590f6796859631213561522ba0b9c1391b67d59/5338.clinic-flame.html

Try toggling `async` or `bunyan` for some highly visible examples.