### PR TITLE
Add line/column numbers to info box paths

### DIFF
--- a/visualizer/info-box.css
+++ b/visualizer/info-box.css
@@ -60,6 +60,10 @@
   max-width: 66.67%;
 }
 
+#info-box .frame-line-col {
+  color: var(--primary-grey);
+  white-space: nowrap;
+}
 
 
 /* presentation mode */

--- a/visualizer/info-box.js
+++ b/visualizer/info-box.js
@@ -12,7 +12,7 @@ class InfoBox extends HtmlContent {
     } = getNoDataNode()
 
     this.functionText = functionName
-    this.pathText = fileName
+    this.pathHtml = fileName
     this.areaText = 'Processing data...'
   }
 
@@ -45,10 +45,10 @@ class InfoBox extends HtmlContent {
 
     this.functionText = node.functionName
 
-    this.pathText = node.fileName
+    this.pathHtml = node.fileName
     if (node.lineNumber && node.columnNumber) {
       // Two spaces (in <pre> tag) so this is visually linked to but distinct from main path, including when wrapped
-      this.pathText += `  <span class="frame-line-col">line:${node.lineNumber} column:${node.columnNumber}</span>`
+      this.pathHtml += `  <span class="frame-line-col">line:${node.lineNumber} column:${node.columnNumber}</span>`
     }
 
     this.rankNumber = this.ui.dataTree.getSortPosition(node)
@@ -76,7 +76,7 @@ class InfoBox extends HtmlContent {
     super.draw()
 
     this.d3FrameFunction.text(this.functionText)
-    this.d3FramePath.html(this.pathText)
+    this.d3FramePath.html(this.pathHtml)
     this.d3FrameArea.text(this.areaText)
   }
 }

--- a/visualizer/info-box.js
+++ b/visualizer/info-box.js
@@ -44,7 +44,13 @@ class InfoBox extends HtmlContent {
     }
 
     this.functionText = node.functionName
+
     this.pathText = node.fileName
+    if (node.lineNumber && node.columnNumber) {
+      // Two spaces (in <pre> tag) so this is visually linked to but distinct from main path, including when wrapped
+      this.pathText += `  <span class="frame-line-col">line:${node.lineNumber} column:${node.columnNumber}</span>`
+    }
+
     this.rankNumber = this.ui.dataTree.getSortPosition(node)
 
     const typeLabel = node.category === 'core' ? '' : ` (${this.ui.getLabelFromKey(`${node.category}:${node.type}`, true)})`
@@ -70,7 +76,7 @@ class InfoBox extends HtmlContent {
     super.draw()
 
     this.d3FrameFunction.text(this.functionText)
-    this.d3FramePath.text(this.pathText)
+    this.d3FramePath.html(this.pathText)
     this.d3FrameArea.text(this.areaText)
   }
 }

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -95,7 +95,9 @@ html.light {
 html.presentation-mode {
   --banner-bg-color: rgb(120, 122, 128);
   --main-bg-color: rgb(76, 78, 84);
+
   --grey-highlight: rgb(255, 255, 255);
+  --primary-grey: rgb(var(--grey-highlight-color-val));
 
   --area-color-deps: rgb(145, 210, 255);
   --area-color-core: rgb(160, 155, 215);


### PR DESCRIPTION
Adds "line:X column:Y" to the text in the info box, like this:

![image](https://user-images.githubusercontent.com/29628323/49696852-44abfe00-fba8-11e8-93a5-005837b03ea7.png)

- Explicitly says these are line and column numbers in full, because we've got space to follow the pattern of space-saving form on the flamegraph vs written more completely in the info box
- Written with colons (line:X column:Y) to complement the truncated form (:X:Y) used on the flamegraph
- Slightly darker than the path text with two spaces separating it, so the path is still visually one unit and still nice and clean and easy to read
- `white-space: nowrap` so that the line and column numbers stick together. So it wraps like this:

![image](https://user-images.githubusercontent.com/29628323/49696911-cef46200-fba8-11e8-95dc-ef39b4324908.png)

...not like this:

![image](https://user-images.githubusercontent.com/29628323/49696914-dd427e00-fba8-11e8-9979-23d46c23810e.png)

