### PR TITLE
Reword labels of unmerged frames to be simply "Optimized" or "Unoptimized"

### DIFF
--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -48,8 +48,8 @@ class FrameNode {
       this.columnNumber = parseInt(columnNumber, 10)
       this.isInit = isInit != null
       this.isInlinable = isInlinable != null
-      this.isOptimised = optimizationFlag === '~'
-      this.isOptimisable = optimizationFlag === '*'
+      this.isOptimized = optimizationFlag === '~'
+      this.isUnoptimized = optimizationFlag === '*'
     } else {
       const m = this.name.match(cppFrameRx)
       /* istanbul ignore else: Only triggers if there's a bug */
@@ -227,8 +227,8 @@ class FrameNode {
       type: this.type,
       category: this.category,
 
-      isOptimised: this.isOptimised,
-      isOptimisable: this.isOptimisable,
+      isOptimized: this.isOptimized,
+      isUnoptimized: this.isUnoptimized,
       isInlinable: this.isInlinable,
       isInit: this.isInit,
 

--- a/test/analysis-categorise.test.js
+++ b/test/analysis-categorise.test.js
@@ -88,8 +88,8 @@ test('analysis - categorise node properties', (t) => {
   t.equal(customNode.type, 'Contains spaces')
   t.equal(customNode.functionName, 'Unexpected multiple customFlags')
   t.equal(customNode.fileName, '.\\sub_dir\\index.js')
-  t.ok(customNode.isOptimised)
-  t.notOk(customNode.isOptimisable)
+  t.ok(customNode.isOptimized)
+  t.notOk(customNode.isUnoptimized)
   t.notOk(dataTree.isNodeExcluded(customNode))
 
   const depNode = byProps({
@@ -104,8 +104,8 @@ test('analysis - categorise node properties', (t) => {
   t.equal(depNode.fileName, '.\\node_modules\\some-module\\index.js')
   t.equal(depNode.lineNumber, 1)
   t.equal(depNode.columnNumber, 2)
-  t.notOk(depNode.isOptimised)
-  t.ok(depNode.isOptimisable)
+  t.notOk(depNode.isOptimized)
+  t.ok(depNode.isUnoptimized)
   t.notOk(dataTree.isNodeExcluded(depNode))
   dataTree.exclude.add('deps')
   t.ok(dataTree.isNodeExcluded(depNode))
@@ -121,8 +121,8 @@ test('analysis - categorise node properties', (t) => {
   t.equal(regexpNode.type, 'regexp')
   t.equal(regexpNode.functionName, '/[\u0000zA-Z\u0000#$%&\'*+.|~]+$/')
   t.equal(regexpNode.fileName, '[CODE:RegExp]')
-  t.notOk(regexpNode.isOptimised)
-  t.notOk(regexpNode.isOptimisable)
+  t.notOk(regexpNode.isOptimized)
+  t.notOk(regexpNode.isUnoptimized)
   t.ok(dataTree.isNodeExcluded(regexpNode))
 
   // Handle INIT and INLINABLE frames
@@ -137,8 +137,8 @@ test('analysis - categorise node properties', (t) => {
   t.equal(inlinableNode.fileName, './0x/examples/dummy.js')
   t.ok(inlinableNode.isInlinable)
   t.notOk(inlinableNode.isInit)
-  t.notOk(inlinableNode.isOptimised)
-  t.notOk(inlinableNode.isOptimisable)
+  t.notOk(inlinableNode.isOptimized)
+  t.notOk(inlinableNode.isUnoptimized)
   t.notOk(dataTree.isNodeExcluded(inlinableNode))
   dataTree.exclude.add('is:inlinable')
   t.ok(dataTree.isNodeExcluded(inlinableNode))
@@ -153,8 +153,8 @@ test('analysis - categorise node properties', (t) => {
   t.equal(initNode.fileName, './0x/examples/dummy.js')
   t.ok(initNode.isInit)
   t.notOk(initNode.isInlinable)
-  t.notOk(initNode.isOptimised)
-  t.ok(initNode.isOptimisable)
+  t.notOk(initNode.isOptimized)
+  t.ok(initNode.isUnoptimized)
 
   t.ok(dataTree.isNodeExcluded(initNode))
 

--- a/visualizer/flame-graph-label.js
+++ b/visualizer/flame-graph-label.js
@@ -45,8 +45,8 @@ function renderLabel (frameHeight, options) {
 
   if (nodeData.isInlinable) functionName += ' (inlinable)'
 
-  if (this.ui.dataTree.showOptimizationStatus && (nodeData.isOptimised || nodeData.isOptimisable)) {
-    functionName += ` (${nodeData.isOptimised ? 'is optimized' : 'optimizable'})`
+  if (this.ui.dataTree.showOptimizationStatus && (nodeData.isOptimized || nodeData.isUnoptimized)) {
+    functionName += ` (${nodeData.isOptimized ? 'opt.' : 'unopt.'})`
   }
 
   if (fileName === null) {

--- a/visualizer/info-box.js
+++ b/visualizer/info-box.js
@@ -44,7 +44,13 @@ class InfoBox extends HtmlContent {
     }
 
     this.functionText = node.functionName
+
     this.pathText = node.fileName
+    if (node.lineNumber && node.columnNumber) {
+      // Two spaces (in <pre> tag) so this is visually linked to but distinct from main path, including when wrapped
+      this.pathText += `  <span class="frame-line-col">line:${node.lineNumber} column:${node.columnNumber}</span>`
+    }
+
     this.rankNumber = this.ui.dataTree.getSortPosition(node)
 
     const typeLabel = node.category === 'core' ? '' : ` (${this.ui.getLabelFromKey(`${node.category}:${node.type}`, true)})`
@@ -55,8 +61,8 @@ class InfoBox extends HtmlContent {
 
     if (node.isInit) this.areaText += '. In initialization process'
     if (node.isInlinable) this.areaText += '. Inlinable'
-    if (node.isOptimisable) this.areaText += '. Optimizable'
-    if (node.isOptimised) this.areaText += '. Is optimized'
+    if (node.isUnoptimized) this.areaText += '. Unoptimized'
+    if (node.isOptimized) this.areaText += '. Optimized'
     this.areaText += '.'
 
     this.draw()
@@ -70,7 +76,7 @@ class InfoBox extends HtmlContent {
     super.draw()
 
     this.d3FrameFunction.text(this.functionText)
-    this.d3FramePath.text(this.pathText)
+    this.d3FramePath.html(this.pathText)
     this.d3FrameArea.text(this.areaText)
   }
 }

--- a/visualizer/key.js
+++ b/visualizer/key.js
@@ -49,17 +49,17 @@ class Key extends HtmlContent {
     const showOpt = this.ui.dataTree.showOptimizationStatus
 
     this.d3Key1
-      .text(showOpt ? 'Optimizable' : this.appName)
+      .text(showOpt ? 'Unoptimized' : this.appName)
       .style('color', this.ui.getFrameColor({
         category: 'app',
-        isOptimisable: true
+        isUnoptimized: true
       }, 'foreground', false))
 
     this.d3Key2
-      .text(showOpt ? 'Is optimized' : this.deps)
+      .text(showOpt ? 'Optimized' : this.deps)
       .style('color', this.ui.getFrameColor({
         category: 'deps',
-        isOptimised: true
+        isOptimized: true
       }, 'foreground', false))
 
     this.d3Key3

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -502,8 +502,8 @@ class Ui extends events.EventEmitter {
     }
 
     if (this.dataTree.showOptimizationStatus) {
-      if (nodeData.isOptimisable) return this.exposedCSS['max-contrast']
-      if (nodeData.isOptimised) return this.exposedCSS['primary-grey']
+      if (nodeData.isUnoptimized) return this.exposedCSS['max-contrast']
+      if (nodeData.isOptimized) return this.exposedCSS['primary-grey']
       return this.exposedCSS['grey-blue']
     } else {
       return this.exposedCSS[nodeData.category]


### PR DESCRIPTION
While working on the relevant documentation, I realised the way these labels were worded was potentially slightly misleading. 

 - [x] Americanises the spelling everywhere ("z" not "s"), since this is a technical V8 terminology not the general meaning of the words.
 - [x] Sticks to the exact forms "Optimized" and "Unoptimized"
 - [x] Shortens the labels shown on the flamegraph itself when "Show optimisation status" is selected, to "(opt.)" or "(unopt.)"

For example (this is with "Merge" unticked and "Show optimization status" ticked, see top right, bottom right, and on the flamegraph):

![image](https://user-images.githubusercontent.com/29628323/49699650-9d40c280-fbcb-11e8-8054-58140d5074b8.png)
