### PR TITLE
#52 - Ensure minHeight is set to graph container height

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "browserify-inline-svg": "^1.0.2",
     "copy-to-clipboard": "^3.0.8",
     "d3-array": "^2.0.2",
-    "d3-fg": "^6.12.0",
+    "d3-fg": "^6.13.0",
     "d3-selection": "^1.3.2",
     "deepmerge": "^2.1.1",
     "flame-gradient": "^1.0.0",

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -336,9 +336,11 @@ class FlameGraph extends HtmlContent {
     this.baseCellHeight = this.ui.presentationMode ? 26 : 20
     const width = this.d3Chart.node().clientWidth
     const cellHeight = this.baseCellHeight + zoomFactor
-    this.sizeChanged = this.width !== width || this.cellHeight !== cellHeight
+    const minHeight = this.d3Element.node().clientHeight
+    this.sizeChanged = this.width !== width || this.cellHeight !== cellHeight || this.minHeight !== minHeight
     this.width = width
     this.cellHeight = cellHeight
+    this.minHeight = minHeight
     this.draw()
     this.updateMarkerBoxes()
   }
@@ -359,6 +361,7 @@ class FlameGraph extends HtmlContent {
     if (this.sizeChanged) {
       this.flameGraph.width(this.width)
       this.flameGraph.cellHeight(this.cellHeight)
+      this.flameGraph.minHeight(this.minHeight)
       this.sizeChanged = false
     }
 

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -126,7 +126,7 @@ class FlameGraph extends HtmlContent {
   }
 
   initializeFromData () {
-    const { dataTree } = this.ui
+    const { dataTree, flameWrapper } = this.ui
 
     this.renderedTree = dataTree.activeTree()
     this.flameGraph = d3Fg({
@@ -138,7 +138,7 @@ class FlameGraph extends HtmlContent {
       element: this.d3Chart.node(),
       cellHeight: this.cellHeight,
       collapseHiddenNodeWidths: true,
-      minHeight: window.screen.availHeight,
+      minHeight: flameWrapper.d3Element.node().clientHeight,
       frameColors: {
         fill: '#000',
         stroke: '#363b4c'

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -126,7 +126,7 @@ class FlameGraph extends HtmlContent {
   }
 
   initializeFromData () {
-    const { dataTree, flameWrapper } = this.ui
+    const { dataTree } = this.ui
 
     this.renderedTree = dataTree.activeTree()
     this.flameGraph = d3Fg({
@@ -138,7 +138,7 @@ class FlameGraph extends HtmlContent {
       element: this.d3Chart.node(),
       cellHeight: this.cellHeight,
       collapseHiddenNodeWidths: true,
-      minHeight: flameWrapper.d3Element.node().clientHeight,
+      minHeight: this.d3Element.node().clientHeight,
       frameColors: {
         fill: '#000',
         stroke: '#363b4c'


### PR DESCRIPTION
This works in unison with [this d3-fg PR](https://github.com/davidmarkclements/d3-fg/pull/29) to fix the issue with a floating flame graphs, by using a more appropriate minHeight.

## Testing
Once [the d3-fg PR](https://github.com/davidmarkclements/d3-fg/pull/29) is merged, you'll need to generate a shallow stack by analysis and simple script to replicate the bug. With this branch linked to Clinic, it should generate a flame graph positioned at the bottom.