### PR TITLE
Implement new URLs to controls docs in more info links

### DIFF
--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -395,11 +395,11 @@ class Ui extends events.EventEmitter {
   getDescriptionFromKey (key) {
     const keysToDescriptions = {
       'core': `JS functions in core Node.js APIs.`,
-      'all-v8': 'The JavaScript engine used by default in Node.js',
+      'all-v8': `The JavaScript engine used by default in Node.js. ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-v8')}`,
       'all-v8:v8': `Operations in V8's implementation of JS. ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-v8-runtime')}`,
       'all-v8:native': `JS compiled into V8, such as prototype methods and eval. ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-v8-native')}`,
-      'all-v8:cpp': `Native C++ operations called by V8, including shared libraries. ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-c')}`,
-      'all-v8:regexp': `The RegExp notation is shown as the function name. ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-rx')}`
+      'all-v8:cpp': `Native C++ operations called by V8, including shared libraries. ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-v8-cpp')}`,
+      'all-v8:regexp': `The RegExp notation is shown as the function name. ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-regexp')}`
     }
 
     if (keysToDescriptions[key]) {

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -394,12 +394,12 @@ class Ui extends events.EventEmitter {
 
   getDescriptionFromKey (key) {
     const keysToDescriptions = {
-      'core': `JS functions in core Node.js APIs. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#core">More info</a>`,
+      'core': `JS functions in core Node.js APIs.`,
       'all-v8': 'The JavaScript engine used by default in Node.js',
-      'all-v8:v8': `Operations in V8's implementation of JS. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#v8">More info</a>`,
-      'all-v8:native': `JS compiled into V8, such as prototype methods and eval. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#native">More info</a>`,
-      'all-v8:cpp': `Native C++ operations called by V8, including shared libraries. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#cpp">More info</a>`,
-      'all-v8:regexp': `The RegExp notation is shown as the function name. <a target="_blank" class="more-info" href="https://clinicjs.org/flame/walkthrough/controls/#rx">More info</a>`
+      'all-v8:v8': `Operations in V8's implementation of JS. ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-v8-runtime')}`,
+      'all-v8:native': `JS compiled into V8, such as prototype methods and eval. ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-v8-native')}`,
+      'all-v8:cpp': `Native C++ operations called by V8, including shared libraries. ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-c')}`,
+      'all-v8:regexp': `The RegExp notation is shown as the function name. ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-rx')}`
     }
 
     if (keysToDescriptions[key]) {
@@ -547,6 +547,14 @@ class Ui extends events.EventEmitter {
 
     // setting Presentation Mode
     this.setPresentationMode(this.presentationMode)
+  }
+
+  createMoreInfoLink (href) {
+    return `
+      <a target="_blank" rel="noopener noreferrer" href="${href}" class="more-info">
+        More info
+      </a>
+    `
   }
 }
 


### PR DESCRIPTION
Works in conjunction with this [website PR](https://github.com/nearform/clinicjs-website/pull/110) which should be merged first.

Simply updates the links to point to relevant section on Flame docs for advanced controls.