### PR TITLE
[WIP] - Use JS/CSS build scripts and main template from Clinic Common

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,14 +132,13 @@ class ClinicFlame extends events.EventEmitter {
       basePath: __dirname
     }))
 
-    // build CSS
+    // uild CSS
     const styleFile = buildCss({
       stylePath,
       debug: this.debug
     })
 
-    // This basic HTML template will be migrated to node-clinic-common and shared between tools,
-    // piping in tool name, logo etc. Customise tool-specific html in node-clinic-toolname/visualizer
+    // generate HTML
     const outputFile = mainTemplate({
       favicon: clinicFaviconBase64,
       title: 'Clinic Flame',

--- a/index.js
+++ b/index.js
@@ -16,11 +16,10 @@ const { promisify } = require('util')
 const readFile = promisify(require('fs').readFile)
 const postcss = require('postcss')
 const postcssImport = require('postcss-import')
-// const minifyStream = require('minify-stream')
-const streamTemplate = require('stream-template')
 const pump = require('pump')
 const browserify = require('browserify')
 const envify = require('loose-envify/custom')
+const mainTemplate = require('@nearform/clinic-common/templates/main')
 
 class ClinicFlame extends events.EventEmitter {
   constructor (settings = {}) {
@@ -159,33 +158,19 @@ class ClinicFlame extends events.EventEmitter {
 
     // This basic HTML template will be migrated to node-clinic-common and shared between tools,
     // piping in tool name, logo etc. Customise tool-specific html in node-clinic-toolname/visualizer
-    const outputFile = streamTemplate`
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <meta charset="utf8">
-          <style>${styleFile}</style>
-          <meta name="viewport" content="width=device-width">
-          <title>Clinic Flame</title>
-          <link rel="shortcut icon" type="image/png" href="${clinicFaviconBase64}">
-        </head>
-        <body>
-          <div id="header">
-            <div id="banner">
-              <a id="main-logo" href="https://github.com/nearform/node-clinic-flame" title="Clinic Flame on GitHub" target="_blank">
-                ${logoFile}<span>Flame</span>
-              </a>
-              <a id="company-logo" href="https://nearform.com" title="nearForm" target="_blank">
-                ${nearFormLogoFile}
-              </a>
-            </div>
-          </div>
-
-          <main></main>
-          <script>${scriptFile}</script>
-        </body>
-      </html>
-    `
+    const outputFile = mainTemplate({
+      favicon: clinicFaviconBase64,
+      title: 'Clinic Flame',
+      styles: styleFile,
+      script: scriptFile,
+      headerLogoUrl: 'https://github.com/nearform/node-clinic-flame',
+      headerLogoTitle: 'Clinic Flame on GitHub',
+      headerLogo: logoFile,
+      headerText: 'Flame',
+      nearFormLogo: nearFormLogoFile,
+      uploadId: outputFilename.split('/').pop().split('.html').shift(),
+      body: `<main></main>`
+    })
 
     pump(
       outputFile,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "0x": "^4.7.2",
     "@nearform/clinic-common": "^1.3.1",
     "browserify-inline-svg": "^1.0.2",
-    "brfs": "^2.0.1",
     "copy-to-clipboard": "^3.0.8",
     "d3-array": "^2.0.2",
     "d3-fg": "^6.13.0",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,8 @@
   "dependencies": {
     "0x": "^4.7.2",
     "@nearform/clinic-common": "^1.3.1",
-    "brfs": "^2.0.1",
-    "browserify": "^16.2.2",
     "browserify-inline-svg": "^1.0.2",
+    "brfs": "^2.0.1",
     "copy-to-clipboard": "^3.0.8",
     "d3-array": "^2.0.2",
     "d3-fg": "^6.13.0",
@@ -31,13 +30,8 @@
     "deepmerge": "^2.1.1",
     "flame-gradient": "^1.0.0",
     "lodash.debounce": "^4.0.8",
-    "loose-envify": "^1.4.0",
-    "minify-stream": "^1.2.0",
-    "postcss": "^7.0.0",
-    "postcss-import": "^12.0.0",
     "pump": "^3.0.0",
-    "querystringify": "^2.1.0",
-    "stream-template": "0.0.10"
+    "querystringify": "^2.1.0"
   },
   "devDependencies": {
     "chokidar": "^2.0.4",

--- a/visualizer/main.js
+++ b/visualizer/main.js
@@ -1,6 +1,9 @@
 'use strict'
 require('@nearform/clinic-common/spinner')
 const Ui = require('./ui.js')
+const askBehaviours = require('@nearform/clinic-common/behaviours/ask')
+
+askBehaviours()
 
 const ui = new Ui('main')
 ui.initializeElements()

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -1,3 +1,4 @@
+@import '@nearform/clinic-common/styles/styles.css';
 @import "./toolbar.css";
 @import "./stack-bar.css";
 @import "./key.css";
@@ -45,7 +46,7 @@ html {
 
   --banner-bg-color-val: 50, 53, 61;
   --banner-bg-color: rgb(var(--banner-bg-color-val));
-  --banner-logo-color: rgba(255, 255, 255, 0.87);
+  --nc-colour-header-background: rgb(var(--banner-bg-color-val));
 
   --footer-bg-color: rgb(15, 18, 26);
   --footer-color: rgba(255, 255, 255, 0.9);
@@ -91,6 +92,7 @@ html.light {
   --banner-bg-color: rgba(0, 0, 0, 0.1);
   --footer-bg-color: rgba(0, 0, 0, 0.1);
   --footer-color: rgba(0, 0, 0, 0.9);
+  --nc-colour-header-background: rgba(0, 0, 0, 0.1);
 }
 
 /* Overrides for Presentation mode */
@@ -144,46 +146,9 @@ html * {
   display: none;
 }
 
-/* Banner layout */
+/* Header */
 
-#banner {
-  display: flex;
-  align-items: center;
-  background: var(--banner-bg-color);
-  position: relative;
-  justify-content: space-between;
-  padding: 7px 18px;
-}
-
-#banner #main-logo svg {
-  margin-right: 12px;
-  height: 51px;
-  width: auto;
-}
-
-#banner #main-logo {
-  display: flex;
-  align-items: center;
-}
-
-#banner #main-logo,
-#banner #main-logo:link,
-#banner #main-logo:visited {
-  color: var(--banner-logo-color);
-  font-weight: bold;
-  font-size: 23px;
-  text-decoration: none;
-}
-
-#banner #company-logo svg {
-  height: 21px;
-  width: auto;
-  display: block;
-}
-
-#header {
-  display: flex;
-  flex-direction: column;
+.nc-header {
   flex-shrink: 0;
 }
 

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -531,7 +531,6 @@ class Ui extends events.EventEmitter {
   }
 
   initializeElements () {
-
     // Cascades down tree in addContent() append/prepend order
     this.uiContainer.initializeElements()
   }


### PR DESCRIPTION
## Overview
Pending [this PR](https://github.com/nearform/node-clinic-common/pull/11) being merged and released, this strips out duplicated build scripts for JS and CSS compilation and uses a template function to import a consistent UI chrome along with necessary styles and behaviours.

## [Example output](https://upload.clinicjs.org/public/9c252f76d5d8dae1e70349c694de9d8f9ed4451618f9722eb4f14f80a0e33d47/52492.clinic-flame.html#selectedNode=36&zoomedNode=&exclude=83c0&merged=true)

## Notes
Tests failing whilst `clinic-common` PR is pending. This PR is WIP until that's released and the dependency can be updated.