### PR TITLE
Flame graph percentage display

### DIFF
--- a/visualizer/info-box.css
+++ b/visualizer/info-box.css
@@ -1,7 +1,4 @@
 #info-box {
-  display: flex;
-  flex-direction: row-reverse;
-  justify-content: stretch;
   position: relative;
 }
 
@@ -27,17 +24,22 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  position: absolute;
+  right: 0;
+  bottom: 100%;
+  transform: translateY(-8px);
   min-width: 70px;
-  padding: 2px 8px;
+  padding: 0.3em;
+  font-size: inherit;
   font-weight: bold;
-  background-color: black;
-  color: white;
+  background-color: var(--opposite-contrast);
+  color: var(--max-contrast);
   border: 0;
   cursor: pointer;
 }
 
-#info-box .frame-dropdown:focus {
-  outline: 0;
+#info-box .frame-dropdown:hover {
+  outline: 1px dotted var(--light-glare);
 }
 
 #info-box .frame-dropdown span {
@@ -47,7 +49,7 @@
 
 #info-box .frame-dropdown svg {
   margin-right: -8px;
-  font-size: 2em;
+  font-size: 1.5em;
   transition: transform 0.6s cubic-bezier(0.42, 0, 0.23, 1.65);
 }
 
@@ -58,12 +60,12 @@
 #info-box .collapsible-content-wrapper {
   position: absolute;
   right: 0;
-  top: 100%;
+  top: -8px;
   min-width: 320px;
   padding: 8px;
-  font-size: var(--small-text-size);
+  font-size: inherit;
   color: white;
-  background-color: var(--options-menu-bg-color);
+  background-color: var(--opposite-contrast);
 }
 
 #info-box .collapsible-content-wrapper h2 {

--- a/visualizer/info-box.css
+++ b/visualizer/info-box.css
@@ -1,18 +1,84 @@
+#info-box {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: stretch;
+  position: relative;
+}
+
 #info-box .frame-info {
   background-color: rgba(var(--opposite-color-val), 0.5);
   color: var(--grey-highlight);
   display: flex;
+  flex-grow: 1;
   font-size: var(--normal-text-size);
   height: 2.9em;
   margin: 0;
   overflow: hidden;
-  padding: 2px 8px;
+  padding: 2px 4px;
   white-space: pre-wrap;
 }
 
 #info-box .frame-info:hover {
   height: auto;
   min-height: 2.9em;
+}
+
+#info-box .frame-dropdown {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 70px;
+  padding: 2px 8px;
+  font-weight: bold;
+  background-color: black;
+  color: white;
+  border: 0;
+  cursor: pointer;
+}
+
+#info-box .frame-dropdown:focus {
+  outline: 0;
+}
+
+#info-box .frame-dropdown span {
+  min-width: 36px;
+  text-align: left;
+}
+
+#info-box .frame-dropdown svg {
+  margin-right: -8px;
+  font-size: 2em;
+  transition: transform 0.6s cubic-bezier(0.42, 0, 0.23, 1.65);
+}
+
+#info-box.collapsed .frame-dropdown svg {
+  transform: rotate(180deg);
+}
+
+#info-box .collapsible-content-wrapper {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  min-width: 320px;
+  padding: 8px;
+  font-size: var(--small-text-size);
+  color: white;
+  background-color: var(--options-menu-bg-color);
+}
+
+#info-box .collapsible-content-wrapper h2 {
+  padding: 0 8px 6px 8px;
+  margin: 0 -8px;
+  font-size: var(--small-text-size);
+  border-bottom: 3px solid var(--main-bg-color);
+}
+
+#info-box .collapsible-content-wrapper > :first-child {
+  margin-top: 0;
+}
+
+#info-box .collapsible-content-wrapper > :last-child {
+  margin-bottom: 0;
 }
 
 #info-box .frame-info strong {
@@ -31,7 +97,7 @@
 }
 
 #info-box .frame-info-item {
-  padding: 0 8px;
+  padding: 0 4px;
 }
 
 #info-box .frame-info .frame-path {
@@ -62,9 +128,21 @@
 
 #info-box .frame-line-col {
   color: var(--primary-grey);
-  white-space: nowrap;
 }
 
+#info-box .frame-line-col span {
+  display: none;
+}
+
+@media (min-width: 992px) {
+  #info-box .frame-info {
+    align-items: center;
+  }
+
+  #info-box .frame-line-col span {
+    display: inline-block;
+  }
+}
 
 /* presentation mode */
 .presentation-mode #info-box .frame-info {

--- a/visualizer/info-box.css
+++ b/visualizer/info-box.css
@@ -29,7 +29,7 @@
   bottom: 100%;
   transform: translateY(-8px);
   min-width: 70px;
-  padding: 0.3em;
+  padding: 0.5em 0.3em;
   font-size: inherit;
   font-weight: bold;
   background-color: var(--opposite-contrast);

--- a/visualizer/info-box.js
+++ b/visualizer/info-box.js
@@ -1,6 +1,7 @@
 'use strict'
 const HtmlContent = require('./html-content.js')
 const getNoDataNode = require('./no-data-node.js')
+const caretUpIcon = require('@nearform/clinic-common/icons/caret-up')
 
 class InfoBox extends HtmlContent {
   constructor (parentContent, contentProperties = {}) {
@@ -14,6 +15,16 @@ class InfoBox extends HtmlContent {
     this.functionText = functionName
     this.pathHtml = fileName
     this.areaText = 'Processing data...'
+    this.stackPercentages = {
+      top: 0,
+      overall: 0
+    }
+
+    this.addCollapseControl(true, {
+      classNames: 'frame-dropdown',
+      htmlElementType: 'button',
+      htmlContent: `<span>0%</span> ${caretUpIcon}`
+    })
   }
 
   initializeElements () {
@@ -35,6 +46,35 @@ class InfoBox extends HtmlContent {
     this.d3FrameArea = this.d3FrameInfo.append('span')
       .classed('frame-info-item', true)
       .classed('frame-area', true)
+
+    this.d3StackInfoTitle = this.d3ContentWrapper
+      .append('h2')
+      .text('Stack info')
+
+    this.d3StackPercentageTop = this.d3ContentWrapper
+      .append('p')
+      .classed('frame-percentage', true)
+      .classed('frame-percentage-top', true)
+      .text('0%')
+
+    this.d3StackPercentageOverall = this.d3ContentWrapper
+      .append('p')
+      .classed('frame-percentage', true)
+      .classed('frame-percentage-overall', true)
+      .text('0%')
+
+    this.d3CollapseButton = this.collapseControl.d3Element
+      .attr('title', 'Show stack info')
+
+    // Close when the user clicks outside the options menu.
+    document.body.addEventListener('click', (event) => {
+      if (!this.collapseClose.isCollapsed &&
+          !this.d3CollapseButton.node().contains(event.target) &&
+          !this.d3ContentWrapper.node().contains(event.target)) {
+        this.collapseClose()
+      }
+    },
+    true)
   }
 
   contentFromNode (node) {
@@ -43,12 +83,20 @@ class InfoBox extends HtmlContent {
       return
     }
 
+    // Todo: Use visibleRootValue when ready
+    const totalValue = this.ui.dataTree.activeTree().value
+
+    this.stackPercentages = {
+      top: Math.round(100 * (node.onStackTop.asViewed / totalValue) * 10) / 10,
+      overall: Math.round(100 * (node.value / totalValue) * 10) / 10
+    }
+
     this.functionText = node.functionName
 
-    this.pathHtml = node.fileName
+    this.pathHtml = node.fileName || ''
     if (node.lineNumber && node.columnNumber) {
       // Two spaces (in <pre> tag) so this is visually linked to but distinct from main path, including when wrapped
-      this.pathHtml += `  <span class="frame-line-col">line:${node.lineNumber} column:${node.columnNumber}</span>`
+      this.pathHtml += `<span class="frame-line-col"><span>  line</span>:${node.lineNumber}<span> column</span>:${node.columnNumber}</span>`
     }
 
     this.rankNumber = this.ui.dataTree.getSortPosition(node)
@@ -75,9 +123,12 @@ class InfoBox extends HtmlContent {
   draw () {
     super.draw()
 
-    this.d3FrameFunction.text(this.functionText)
-    this.d3FramePath.html(this.pathHtml)
-    this.d3FrameArea.text(this.areaText)
+    this.d3FrameFunction.text(this.functionText).attr('title', this.functionText)
+    this.d3FramePath.html(this.pathHtml).attr('title', this.pathHtml.replace(/(<([^>]+)>)/ig, ''))
+    this.d3FrameArea.text(this.areaText).attr('title', this.areaText)
+    this.d3CollapseButton.select('span').text(`${this.stackPercentages.top}%`)
+    this.d3StackPercentageTop.text(`Top of stack: ${this.stackPercentages.top}%`)
+    this.d3StackPercentageOverall.text(`On stack: ${this.stackPercentages.overall}%`)
   }
 }
 

--- a/visualizer/selection-controls.css
+++ b/visualizer/selection-controls.css
@@ -36,7 +36,7 @@
 }
 
 .visible-from-bp-1,
-.visible-from-bp-2 .label{
+.visible-from-bp-2 .label {
   display: none;
 }
 
@@ -47,7 +47,7 @@
 }
 
 @media screen and (min-width: 680px) {
-  .visible-from-bp-2 .label{
+  .visible-from-bp-2 .label {
     display: initial;
   }
 }

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -52,6 +52,7 @@ html {
   --banner-bg-color: rgb(var(--banner-bg-color-val));
   --nc-colour-header-background: rgb(var(--banner-bg-color-val));
 
+  --options-menu-bg-color: rgb(15, 18, 26);
   --footer-bg-color: rgb(15, 18, 26);
   --footer-color: rgba(255, 255, 255, 0.9);
 
@@ -95,6 +96,7 @@ html.light {
   --opposite-contrast: rgb(255, 255, 255);
 
   --banner-bg-color: rgba(0, 0, 0, 0.1);
+  --options-menu-bg-color: rgba(0, 0, 0, 0.1);
   --footer-bg-color: rgba(0, 0, 0, 0.1);
   --footer-color: rgba(0, 0, 0, 0.9);
   --nc-colour-header-background: rgba(0, 0, 0, 0.1);
@@ -166,7 +168,7 @@ html * {
   }
   .checkbox .after-bp-1{
     display: inline!important;
-  }  
+  }
 
   .before-bp-1 {
     display: none!important;
@@ -180,7 +182,7 @@ html * {
   }
   .checkbox .after-bp-2{
     display: inline!important;
-  }  
+  }
 
   .before-bp-2 {
     display: none!important;
@@ -198,7 +200,7 @@ div#main-content {
   flex-grow: 1;
   flex-shrink: 1;
   overflow: hidden;
-  position: relative;    
+  position: relative;
   z-index: 0;
 }
 

--- a/visualizer/toolbar.css
+++ b/visualizer/toolbar.css
@@ -20,11 +20,11 @@
 }
 
 
-
 @media screen and (min-width: 500px) {
   #selection-controls {
     margin: 0px;
   }
+
   #toolbar-top-panel {
     justify-content: space-between;
   }
@@ -34,4 +34,10 @@
   #info-box .frame-info {
     font-size: var(--small-text-size);
   }
+}
+
+/* presentation mode */
+.presentation-mode #toolbar-side-panel {
+  background-color: transparent;
+  padding: 0px;
 }

--- a/visualizer/toolbar.css
+++ b/visualizer/toolbar.css
@@ -10,34 +10,13 @@
 
 #toolbar-top-panel {
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   margin: 8px;
   flex-wrap: wrap;
-}
-
-#selection-controls {
-  margin: 8px 8px 0px;
-}
-
-
-@media screen and (min-width: 500px) {
-  #selection-controls {
-    margin: 0px;
-  }
-
-  #toolbar-top-panel {
-    justify-content: space-between;
-  }
 }
 
 @media screen and (min-width: 720px) {
   #info-box .frame-info {
     font-size: var(--small-text-size);
   }
-}
-
-/* presentation mode */
-.presentation-mode #toolbar-side-panel {
-  background-color: transparent;
-  padding: 0px;
 }


### PR DESCRIPTION
## Overview

 - Adds a dropdown inside the info box which displays stack percentages (top and overall)
 - Centres text inside info box
 - Stacks text inside info box on smaller screens with ability to scroll to see all text
 - Adds titles to each text element inside info box in case of massive path or function string

## Before
https://upload.clinicjs.org/public/c748ff5b367a00825f2f8157d85d70c54402cf628b02faa5ca9437a92e63bcb3/49653.clinic-flame.html#selectedNode=207&zoomedNode=&exclude=8000&merged=true

## After
https://upload.clinicjs.org/public/eb6802c7c59ef7005c46ae87e42d1d46fc7f2693bbeb099a8396ea945755c0e4/49653.clinic-flame.html#selectedNode=207&zoomedNode=&exclude=8000&merged=true 