### PR TITLE
Outline code area groupings

### DIFF
--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -5,7 +5,7 @@ const jsFrameRx = /^([~*])?((?:\S+?\(anonymous function\)|\S+)?(?: [a-zA-Z]+)*) 
 const cppFrameRx = /^(.*) (\[CPP]|\[SHARED_LIB]|\[CODE:\w+])( \[INIT])?$/m
 
 class FrameNode {
-  constructor (data) {
+  constructor (data, fixedType = null) {
     this.id = null
 
     /* istanbul ignore next: must be a string; can be null but can't replicate in tests */
@@ -24,8 +24,10 @@ class FrameNode {
     this.lineNumber = null
     this.columnNumber = null
 
-    // Don't try to identify anything for the root node.
-    if (this.name === 'all stacks') {
+    // Don't try to identify anything for the root node
+    if (fixedType) {
+      this.category = 'none'
+      this.type = fixedType
       return this
     }
 
@@ -81,6 +83,7 @@ class FrameNode {
   }
 
   categorise (systemInfo, appName) {
+    if (this.category === 'none') return
     const { name } = this // this.name remains unmutated: the initial name returned by 0x
 
     const {
@@ -190,6 +193,7 @@ class FrameNode {
   }
 
   format (systemInfo) {
+    if (this.category === 'none') return
     this.anonymise(systemInfo)
     this.target = this.getTarget(systemInfo) // Optional; where a user can view the source (e.g. path, url...)
   }

--- a/analysis/index.js
+++ b/analysis/index.js
@@ -42,8 +42,8 @@ async function analyse (paths) {
   ]
 
   const trees = ticksToTree(ticks, { inlined })
-  const merged = new FrameNode(trees.merged)
-  const unmerged = new FrameNode(trees.unmerged)
+  const merged = new FrameNode(trees.merged, 'root')
+  const unmerged = new FrameNode(trees.unmerged, 'root')
   steps.forEach((step) => {
     step(merged)
     step(unmerged)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "browserify-inline-svg": "^1.0.2",
     "copy-to-clipboard": "^3.0.8",
     "d3-array": "^2.0.2",
-    "d3-fg": "^6.13.0",
+    "d3-fg": "^6.13.1",
     "d3-selection": "^1.3.2",
     "deepmerge": "^2.1.1",
     "flame-gradient": "^1.0.0",

--- a/test/visualizer-data-tree.test.js
+++ b/test/visualizer-data-tree.test.js
@@ -12,13 +12,13 @@ test('visualizer - data tree - sort frames by code area and stack top value', {
     // Fastify totals 260
     // → fastify should be first
     children: [
-      { category: 'deps', typeTEMP: 'fastify', value: 100, onStackTop: { base: 100 }, children: [] },
+      { category: 'deps', type: 'fastify', value: 100, onStackTop: { base: 100 }, children: [] },
       { category: 'all-core', type: 'core', value: 200, onStackTop: { base: 200 }, children: [] },
-      { category: 'deps', typeTEMP: 'fastify', value: 20, onStackTop: { base: 20 }, children: [] },
-      { category: 'app', typeTEMP: '.', value: 115, onStackTop: { base: 115 }, children: [] },
-      { category: 'app', typeTEMP: '.', value: 116, onStackTop: { base: 116 }, children: [] },
-      { category: 'deps', typeTEMP: 'fastify', value: 40, onStackTop: { base: 40 }, children: [] },
-      { category: 'deps', typeTEMP: 'fastify', value: 100, onStackTop: { base: 100 }, children: [] }
+      { category: 'deps', type: 'fastify', value: 20, onStackTop: { base: 20 }, children: [] },
+      { category: 'app', type: '.', value: 115, onStackTop: { base: 115 }, children: [] },
+      { category: 'app', type: '.', value: 116, onStackTop: { base: 116 }, children: [] },
+      { category: 'deps', type: 'fastify', value: 40, onStackTop: { base: 40 }, children: [] },
+      { category: 'deps', type: 'fastify', value: 100, onStackTop: { base: 100 }, children: [] }
     ]
   }
 
@@ -36,12 +36,12 @@ test('visualizer - data tree - sort frames by code area and stack top value', {
   // Use match() rather than same(), because DataTree adds some properties
   // like `onStackTop.asViewed` that are not relevant for this test
   t.match(sorted, [
-    { category: 'deps', typeTEMP: 'fastify', value: 100 },
-    { category: 'deps', typeTEMP: 'fastify', value: 100 },
-    { category: 'deps', typeTEMP: 'fastify', value: 40 },
-    { category: 'deps', typeTEMP: 'fastify', value: 20 },
-    { category: 'app', typeTEMP: '.', value: 116 },
-    { category: 'app', typeTEMP: '.', value: 115 },
+    { category: 'deps', type: 'fastify', value: 100 },
+    { category: 'deps', type: 'fastify', value: 100 },
+    { category: 'deps', type: 'fastify', value: 40 },
+    { category: 'deps', type: 'fastify', value: 20 },
+    { category: 'app', type: '.', value: 116 },
+    { category: 'app', type: '.', value: 115 },
     { category: 'all-core', type: 'core', value: 200 }
   ])
 
@@ -52,16 +52,16 @@ test('visualizer - data tree - sort frames by code area and stack top value', {
     .sort(tree.getFilteredStackSorter())
 
   t.match(sorted2, [
-    { category: 'deps', typeTEMP: 'fastify', value: 100 },
-    { category: 'deps', typeTEMP: 'fastify', value: 100 },
-    { category: 'deps', typeTEMP: 'fastify', value: 40 },
-    { category: 'deps', typeTEMP: 'fastify', value: 20 },
+    { category: 'deps', type: 'fastify', value: 100 },
+    { category: 'deps', type: 'fastify', value: 100 },
+    { category: 'deps', type: 'fastify', value: 40 },
+    { category: 'deps', type: 'fastify', value: 20 },
     { category: 'all-core', type: 'core', value: 200 },
     // NOTE these are not sorted by value—they don't need to be
     // If this test starts failing we should change the test so it doesn't rely on this order
     // (or change the implementation so it sorts hidden frames by _something_)
-    { category: 'app', typeTEMP: '.', value: 115 },
-    { category: 'app', typeTEMP: '.', value: 116 }
+    { category: 'app', type: '.', value: 115 },
+    { category: 'app', type: '.', value: 116 }
   ])
 
   t.end()

--- a/test/visualizer-data-tree.test.js
+++ b/test/visualizer-data-tree.test.js
@@ -1,9 +1,7 @@
 const test = require('tap').test
 const DataTree = require('../visualizer/data-tree.js')
 
-test('visualizer - data tree - sort frames by code area and stack top value', {
-  skip: 'currently disabled by the comment in data-tree.js'
-}, (t) => {
+test('visualizer - data tree - sort frames by code area and stack top value', (t) => {
   const rootNode = {
     name: 'all stacks',
     value: 2,

--- a/visualizer/data-tree.js
+++ b/visualizer/data-tree.js
@@ -149,12 +149,10 @@ class DataTree {
 
   getFilteredStackSorter () {
     return (nodeA, nodeB) => {
-      /** TODO enable grouped sorting when UI is ready
       const groupA = this.groupedSortValues.get(nodeA)
       const groupB = this.groupedSortValues.get(nodeB)
       if (groupA > groupB) return -1
       if (groupA < groupB) return 1
-      */
 
       const valueA = this.getNodeValue(nodeA)
       const valueB = this.getNodeValue(nodeB)

--- a/visualizer/data-tree.js
+++ b/visualizer/data-tree.js
@@ -167,7 +167,7 @@ class DataTree {
     this.groupedSortValues = new Map()
 
     function getTypeKey (node) {
-      return `${node.category}:${node.typeTEMP !== undefined ? node.typeTEMP : node.type}`
+      return `${node.category}:${node.type}`
     }
 
     const walk = (node) => {

--- a/visualizer/data-tree.js
+++ b/visualizer/data-tree.js
@@ -212,8 +212,6 @@ class DataTree {
   }
 
   getTypeKey (node) {
-    if (this.isNodeExcluded(node)) {
-    }
     return `${node.category}:${node.type}`
   }
 

--- a/visualizer/data-tree.js
+++ b/visualizer/data-tree.js
@@ -166,15 +166,19 @@ class DataTree {
   computeGroupedSortValues () {
     this.groupedSortValues = new Map()
 
-    function getTypeKey (node) {
-      return `${node.category}:${node.type}`
-    }
+    const completeNodesArray = [ this.activeTree() ].concat(this.activeNodes())
 
-    const walk = (node) => {
-      if (!node.children) return
+    completeNodesArray.forEach(node => {
       const group = Object.create(null)
-      node.children.forEach((child) => {
-        const type = getTypeKey(child)
+      node.childGroups = group
+
+      if (!node.children || this.isNodeExcluded(node)) return
+
+      const nextVisibleDescendents = this.getNextVisible(node)
+
+      nextVisibleDescendents.forEach((child) => {
+        if (!this.isNodeExcluded(child)) console.log(child, node)
+        const type = this.getTypeKey(child)
         const value = this.getNodeValue(child)
         if (type in group) {
           group[type] += value
@@ -183,16 +187,13 @@ class DataTree {
         }
       })
 
-      node.children.forEach((child) => {
-        const type = getTypeKey(child)
+      nextVisibleDescendents.forEach((child) => {
+        const type = this.getTypeKey(child)
         this.groupedSortValues.set(child, group[type])
-        walk(child)
       })
 
       node.childGroups = group
-    }
-
-    walk(this.activeTree())
+    })
   }
 
   isOffScreen (node) {
@@ -211,6 +212,12 @@ class DataTree {
     return this.isOffScreen(node) ? node.original : node.value
   }
 
+  getTypeKey (node) {
+    if (this.isNodeExcluded(node)) {
+    }
+    return `${node.category}:${node.type}`
+  }
+
   getSortPosition (node, arr = this.flatByHottest) {
     return arr.indexOf(node)
   }
@@ -222,6 +229,20 @@ class DataTree {
   getNodeById (id) {
     const arr = this.activeNodes()
     return arr.find((node) => node.id === id)
+  }
+
+  getNextVisible (node = this.activeTree()) {
+    let nextVisibleDescendents = []
+    const childCount = node.children.length
+    for (let i = 0; i < childCount; i++) {
+      const child = node.children[i]
+      if (this.isNodeExcluded(child)) {
+        nextVisibleDescendents = nextVisibleDescendents.concat(this.getNextVisible(child))
+      } else {
+        nextVisibleDescendents.push(child)
+      }
+    }
+    return nextVisibleDescendents
   }
 }
 

--- a/visualizer/data-tree.js
+++ b/visualizer/data-tree.js
@@ -174,10 +174,9 @@ class DataTree {
 
       if (!node.children || this.isNodeExcluded(node)) return
 
-      const nextVisibleDescendents = this.getNextVisible(node)
+      const nextVisibleDescendents = this.getVisibleChildren(node)
 
       nextVisibleDescendents.forEach((child) => {
-        if (!this.isNodeExcluded(child)) console.log(child, node)
         const type = this.getTypeKey(child)
         const value = this.getNodeValue(child)
         if (type in group) {
@@ -231,13 +230,15 @@ class DataTree {
     return arr.find((node) => node.id === id)
   }
 
-  getNextVisible (node = this.activeTree()) {
+  getVisibleChildren (node = this.activeTree()) {
+    // Can pass in data nodes or D3 partition nodes; gets closest visible descendents of same type
+
     let nextVisibleDescendents = []
-    const childCount = node.children.length
+    const childCount = node.children ? node.children.length : 0
     for (let i = 0; i < childCount; i++) {
       const child = node.children[i]
-      if (this.isNodeExcluded(child)) {
-        nextVisibleDescendents = nextVisibleDescendents.concat(this.getNextVisible(child))
+      if (this.isNodeExcluded(child.data || child)) {
+        nextVisibleDescendents = nextVisibleDescendents.concat(this.getVisibleChildren(child))
       } else {
         nextVisibleDescendents.push(child)
       }

--- a/visualizer/flame-graph-frame.js
+++ b/visualizer/flame-graph-frame.js
@@ -40,12 +40,14 @@ function renderStackFrame (globals, locals, rect) {
 
   // Don't redraw heat over previous paint on hover events, and don't draw for root node
   const doDrawHeatBar = state === STATE_IDLE && nodeData.id !== 0
-  if (doDrawHeatBar) renderHeatBar(context, nodeData, colorHash, {
-    x: left,
-    y: top,
-    width: Math.ceil(width) - 1.5,
-    height: heatHeight
-  })
+  if (doDrawHeatBar) {
+    renderHeatBar(context, nodeData, colorHash, {
+      x: left,
+      y: top,
+      width: Math.ceil(width) - 1.5,
+      height: heatHeight
+    })
+  }
 
   const backgroundColor = this.ui.getFrameColor(nodeData, 'background')
   const foregroundColor = this.ui.getFrameColor(nodeData, 'foreground')

--- a/visualizer/flame-graph-frame.js
+++ b/visualizer/flame-graph-frame.js
@@ -52,9 +52,6 @@ function renderStackFrame (globals, locals, rect) {
   const backgroundColor = this.ui.getFrameColor(nodeData, 'background')
   const foregroundColor = this.ui.getFrameColor(nodeData, 'foreground')
 
-  const visibleParent = this.getVisibleParent(node)
-  const parentForegroundColor = visibleParent ? this.ui.getFrameColor(visibleParent.data, 'foreground') : foregroundColor
-
   context.fillStyle = backgroundColor
 
   context.beginPath()
@@ -68,6 +65,7 @@ function renderStackFrame (globals, locals, rect) {
   context.clearRect(left, y, Math.min(width, 0.1), height)
   context.fill()
 
+  const visibleParent = this.getVisibleParent(node)
   if (!visibleParent) {
     context.restore()
     return

--- a/visualizer/flame-graph-frame.js
+++ b/visualizer/flame-graph-frame.js
@@ -91,10 +91,11 @@ function renderStackFrame (globals, locals, rect) {
   const alphaReduced = this.ui.presentationMode ? 0.25 : 0.2
 
   const areaChangeBelow = !sameArea(nodeData, visibleParent.data)
-
   const areaChangeLeft = !previousSibling || !sameArea(nodeData, previousSibling.data)
   const areaChangeRight = !nextSibling || !sameArea(nodeData, nextSibling.data)
   const categoryChangeBelow = nodeData.category !== visibleParent.data.category
+
+  const leftGapRemover = !areaChangeLeft && areaChangeBelow ? 1 : 0
 
   context.globalAlpha = (areaChangeBelow ? alphaFull : alphaReduced) * thinFrameReducer
 
@@ -103,7 +104,7 @@ function renderStackFrame (globals, locals, rect) {
     context.strokeStyle = parentForegroundColor
 
     context.beginPath()
-    context.moveTo(left, bottom - lineWidth * 1.5)
+    context.moveTo(left - leftGapRemover, bottom - lineWidth * 1.5)
     context.lineTo(right, bottom - lineWidth * 1.5)
     context.stroke()
   }
@@ -111,7 +112,7 @@ function renderStackFrame (globals, locals, rect) {
   context.strokeStyle = foregroundColor
 
   context.beginPath()
-  context.moveTo(left, bottom - lineWidth * (categoryChangeBelow ? 2.5 : 1))
+  context.moveTo(left - leftGapRemover, bottom - lineWidth * (categoryChangeBelow ? 2.5 : 1))
   context.lineTo(right, bottom - lineWidth * (categoryChangeBelow ? 2.5 : 1))
   context.stroke()
 

--- a/visualizer/flame-graph-frame.js
+++ b/visualizer/flame-graph-frame.js
@@ -40,7 +40,12 @@ function renderStackFrame (globals, locals, rect) {
 
   // Don't redraw heat over previous paint on hover events, and don't draw for root node
   const doDrawHeatBar = state === STATE_IDLE && nodeData.id !== 0
-  if (doDrawHeatBar) renderHeatBar(context, nodeData, colorHash, rect, heatHeight)
+  if (doDrawHeatBar) renderHeatBar(context, nodeData, colorHash, {
+    x: left,
+    y: top,
+    width: Math.ceil(width) - 1.5,
+    height: heatHeight
+  })
 
   const backgroundColor = this.ui.getFrameColor(nodeData, 'background')
   const foregroundColor = this.ui.getFrameColor(nodeData, 'foreground')
@@ -164,7 +169,7 @@ function renderStackFrame (globals, locals, rect) {
   }
 }
 
-function renderHeatBar (context, nodeData, colorHash, rect, heatHeight) {
+function renderHeatBar (context, nodeData, colorHash, rect) {
   // Extracted from d3-fg so we can pixel-align it to match the rest
   const heatColor = colorHash(nodeData)
   const heatStrokeColor = colorHash(nodeData, 1.1)
@@ -172,7 +177,7 @@ function renderHeatBar (context, nodeData, colorHash, rect, heatHeight) {
   context.fillStyle = heatColor
   context.strokeStyle = heatStrokeColor
   context.beginPath()
-  context.rect(rect.x, rect.y - heatHeight, rect.width, heatHeight)
+  context.rect(rect.x, rect.y - rect.height, rect.width, rect.height)
   context.fill()
   context.stroke()
 }

--- a/visualizer/flame-graph-frame.js
+++ b/visualizer/flame-graph-frame.js
@@ -52,7 +52,7 @@ function renderStackFrame (globals, locals, rect) {
   const backgroundColor = this.ui.getFrameColor(nodeData, 'background')
   const foregroundColor = this.ui.getFrameColor(nodeData, 'foreground')
 
-  const visibleParent = getVisibleParent(node)
+  const visibleParent = this.getVisibleParent(node)
   const parentForegroundColor = visibleParent ? this.ui.getFrameColor(visibleParent.data, 'foreground') : foregroundColor
 
   context.fillStyle = backgroundColor
@@ -100,27 +100,18 @@ function renderStackFrame (globals, locals, rect) {
   const areaChangeBelow = !sameArea(nodeData, visibleParent.data)
   const areaChangeLeft = !previousSibling || !sameArea(nodeData, previousSibling.data)
   const areaChangeRight = !nextSibling || !sameArea(nodeData, nextSibling.data)
-  const categoryChangeBelow = nodeData.category !== visibleParent.data.category
 
   const leftGapRemover = !areaChangeLeft && areaChangeBelow ? 1 : 0
 
   context.globalAlpha = (areaChangeBelow ? alphaFull : alphaReduced) * thinFrameReducer
 
-  context.lineWidth = lineWidth * (categoryChangeBelow ? 2 : 1)
-  if (categoryChangeBelow) {
-    context.strokeStyle = parentForegroundColor
-
-    context.beginPath()
-    context.moveTo(left - leftGapRemover, bottom - lineWidth * 1.5)
-    context.lineTo(right, bottom - lineWidth * 1.5)
-    context.stroke()
-  }
+  context.lineWidth = lineWidth
 
   context.strokeStyle = foregroundColor
 
   context.beginPath()
-  context.moveTo(left - leftGapRemover, bottom - lineWidth * (categoryChangeBelow ? 2.5 : 1))
-  context.lineTo(right, bottom - lineWidth * (categoryChangeBelow ? 2.5 : 1))
+  context.moveTo(left - leftGapRemover, bottom - lineWidth)
+  context.lineTo(right, bottom - lineWidth)
   context.stroke()
 
   context.lineWidth = lineWidth
@@ -167,7 +158,7 @@ function renderStackFrame (globals, locals, rect) {
       priorSiblingWidth += (visibleSiblings[i].x1 - visibleSiblings[i].x0) * widthRatio
     }
 
-    this.labelArea({ context: this.overlayContext, node, state }, rect, priorSiblingWidth)
+    this.labelArea({ context: this.overlayContext, node, state }, rect, priorSiblingWidth, lineWidth, alphaFull)
   }
 }
 
@@ -182,11 +173,6 @@ function renderHeatBar (context, nodeData, colorHash, rect) {
   context.rect(rect.x, rect.y - rect.height, rect.width, rect.height)
   context.fill()
   context.stroke()
-}
-
-function getVisibleParent (node) {
-  if (!node.parent) return null
-  return node.parent.data.hide ? getVisibleParent(node.parent) : node.parent
 }
 
 function sameArea (nodeDataA, nodeDataB) {

--- a/visualizer/flame-graph-frame.js
+++ b/visualizer/flame-graph-frame.js
@@ -62,11 +62,11 @@ function renderStackFrame (globals, locals, rect) {
 
   context.save()
 
-  // For narrow frames with very little between lines, fade fill or skip fill completely
-  if (width > lineWidth) {
-    context.globalAlpha = Math.min(1, Math.max(width - lineWidth, 0.1) / lineWidth * 3)
-    context.fill()
-  }
+  // Make the very narrowest frames feinter relative to how narrow they are
+  if (width > lineWidth) context.globalAlpha = Math.min(1, Math.max(width - lineWidth, 0.5) / lineWidth * 3)
+  // Clear before fill so that even if very narrow frames are feint, height from below doesn't show through
+  context.clearRect(left, y, Math.min(width, 0.1), height)
+  context.fill()
 
   if (!visibleParent) {
     context.restore()

--- a/visualizer/flame-graph-label.js
+++ b/visualizer/flame-graph-label.js
@@ -98,6 +98,8 @@ function renderFrameLabel (frameHeight, options) {
 }
 
 function renderAreaLabel (locals, rect, priorSiblingWidth) {
+  if (this.isAnimating) return
+
   const {
     context,
     node

--- a/visualizer/flame-graph-label.js
+++ b/visualizer/flame-graph-label.js
@@ -122,7 +122,7 @@ function renderAreaLabel (locals, rect, priorSiblingWidth) {
 
   const areaName = (
     nodeData.category === 'core' ? 'node'
-      : nodeData.category === 'all-v8' ? this.ui.getLabelFromKey(`all-v8:${nodeData.type}`)
+      : nodeData.category === 'all-v8' ? this.ui.getLabelFromKey(this.ui.dataTree.getTypeKey(nodeData))
         : nodeData.type
   ).toUpperCase()
   const nameWidth = context.measureText(areaName).width

--- a/visualizer/flame-graph-label.js
+++ b/visualizer/flame-graph-label.js
@@ -55,6 +55,7 @@ function renderFrameLabel (frameHeight, options) {
     if (nodeData.type === 'v8') fileName = 'Compiled V8 C++'
     if (nodeData.type === 'cpp') fileName = 'Compiled C++'
   }
+  if (nodeData.category === 'deps') fileName = fileName.replace(/\.\.?[\\/]node_modules[\\/]/, '')
 
   const funcNameWidth = context.measureText(functionName).width
   const fileNameWidth = context.measureText(fileName).width
@@ -69,7 +70,7 @@ function renderFrameLabel (frameHeight, options) {
       const lineAndColumn = `:${nodeData.lineNumber}:${nodeData.columnNumber}`
       const extraTextWidth = fullTextWidth + context.measureText(lineAndColumn).width
 
-      fileName = extraTextWidth < width ? nodeData.fileName + lineAndColumn : nodeData.fileName
+      fileName = extraTextWidth < width ? fileName + lineAndColumn : fileName
     }
   } else if (this.labelPadding * 4 + funcNameWidth > width) {
     // No file name at all if there's no space for more than one padding width's worth
@@ -85,7 +86,7 @@ function renderFrameLabel (frameHeight, options) {
     // See if we can isolate a file name from its path and show just that
     const pathSeparator = this.ui.dataTree.pathSeparator
     const availableWidth = width - this.labelPadding * 3 - funcNameWidth
-    fileName = truncateFileName(context, availableWidth, fileName, pathSeparator)
+    fileName = truncateFileName(context, availableWidth, fileName, pathSeparator, nodeData)
   }
 
   const coords = {
@@ -170,7 +171,12 @@ function truncateFunctionName (context, availableWidth, functionName, funcNameWi
   return functionName ? functionName + '…' : ''
 }
 
-function truncateFileName (context, availableWidth, fileName, pathSeparator) {
+function truncateFileName (context, availableWidth, fileName, pathSeparator, nodeData) {
+  if (nodeData.category === 'deps') {
+    const removedDep = fileName.replace(new RegExp(`^${nodeData.type}[\\\\/]`), '…')
+    if (context.measureText(removedDep).width <= availableWidth) return removedDep
+  }
+
   let fileOnly = fileName.split(pathSeparator).pop()
 
   if (fileOnly === fileName) return ''

--- a/visualizer/flame-graph-label.js
+++ b/visualizer/flame-graph-label.js
@@ -118,7 +118,11 @@ function renderAreaLabel (locals, rect, priorSiblingWidth) {
 
   if (availableWidth < fontSize) return
 
-  const areaName = (nodeData.category === 'core' ? 'node' : nodeData.type).toUpperCase()
+  const areaName = (
+    nodeData.category === 'core' ? 'node' :
+    nodeData.category === 'all-v8' ? this.ui.getLabelFromKey(`all-v8:${nodeData.type}`) :
+    nodeData.type
+  ).toUpperCase()
   const nameWidth = context.measureText(areaName).width
   const visibleName = truncateFunctionName(context, availableWidth, areaName, nameWidth)
   const visibleNameWidth = context.measureText(visibleName).width

--- a/visualizer/flame-graph-label.js
+++ b/visualizer/flame-graph-label.js
@@ -121,9 +121,9 @@ function renderAreaLabel (locals, rect, priorSiblingWidth) {
   if (availableWidth < fontSize) return
 
   const areaName = (
-    nodeData.category === 'core' ? 'node' :
-    nodeData.category === 'all-v8' ? this.ui.getLabelFromKey(`all-v8:${nodeData.type}`) :
-    nodeData.type
+    nodeData.category === 'core' ? 'node'
+      : nodeData.category === 'all-v8' ? this.ui.getLabelFromKey(`all-v8:${nodeData.type}`)
+        : nodeData.type
   ).toUpperCase()
   const nameWidth = context.measureText(areaName).width
   const visibleName = truncateFunctionName(context, availableWidth, areaName, nameWidth)

--- a/visualizer/flame-graph.css
+++ b/visualizer/flame-graph.css
@@ -30,6 +30,7 @@ chart > div {
   display: none;
   flex-direction: column;
   align-items: center;
+  z-index: 10;
 }
 .highlighter-box {
   display: none;
@@ -74,9 +75,14 @@ chart > div {
 .selection-box {
   position: absolute;
   pointer-events: none;
-  background-color: rgba(var(--grey-highlight-color-val), 0.12);
+  background: rgba(var(--grey-highlight-color-val), 0.12);
+  background: linear-gradient(to bottom,
+    rgba(var(--grey-highlight-color-val), 0.28) 0%,
+    rgba(var(--grey-highlight-color-val), 0.14) 60%,
+    rgba(var(--grey-highlight-color-val), 0) 100%
+  );
   border: 1px solid transparent;
-  box-shadow: 0 1px 4px rgba(var(--grey-highlight-color-val), 0.2);
+  box-shadow: 0 1px 4px rgba(var(--grey-highlight-color-val), 0.14);
   z-index: 10;
 }
 

--- a/visualizer/flame-graph.css
+++ b/visualizer/flame-graph.css
@@ -92,7 +92,7 @@ chart > div {
   top: 0;
   left: 0;
   width: 100%;
-  z-index: 5;
+  z-index: 3;
 }
 
 .zoom-underline {

--- a/visualizer/flame-graph.css
+++ b/visualizer/flame-graph.css
@@ -77,6 +77,16 @@ chart > div {
   background-color: rgba(var(--grey-highlight-color-val), 0.12);
   border: 1px solid transparent;
   box-shadow: 0 1px 4px rgba(var(--grey-highlight-color-val), 0.2);
+  z-index: 10;
+}
+
+#flame-main canvas.flame-overlay {
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 5;
 }
 
 .zoom-underline {

--- a/visualizer/flame-graph.css
+++ b/visualizer/flame-graph.css
@@ -35,7 +35,7 @@ chart > div {
   display: none;
   top: 0px;
   left: 0px;
-  border: 1px dotted rgba(255, 255, 255, 0.5);
+  border: 1px dashed rgba(255, 255, 255, 0.5);
   pointer-events: none;
   position: absolute;
 }
@@ -68,7 +68,7 @@ chart > div {
   content:"";
   flex-grow: 1;
   width: 0px;
-  border-left: 1px dotted rgba(255, 255, 255, 0.5);
+  border-left: 1px dashed rgba(255, 255, 255, 0.5);
 }
 
 .selection-box {

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -432,7 +432,6 @@ class FlameGraph extends HtmlContent {
 
     if (toHide.size > 0 || toShow.size > 0) isChanged = true
     if (isChanged || redrawGraph) this.clearOverlay()
-      // Clear the overlay canvas before it is redrawn
 
     // Must re-render tree before applying exclusions, else error if tree and exclusions change at same time
     if (redrawGraph) this.flameGraph.renderTree(this.renderedTree)

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -274,6 +274,11 @@ class FlameGraph extends HtmlContent {
     return this.flameGraph.getNodeRect(node)
   }
 
+  getVisibleParent (d3Node) {
+    if (!d3Node.parent) return null
+    return d3Node.parent.data.hide ? this.getVisibleParent(d3Node.parent) : d3Node.parent
+  }
+
   highlightHoveredNodeOnGraph () {
     if (this.hoveredNodeData === null) {
       this.d3Highlighter.classed('show', false)
@@ -290,9 +295,9 @@ class FlameGraph extends HtmlContent {
       this.applyRectToDiv(this.d3HighlighterBox, {
         // Align border inside frame so it's visible against borders, heat etc
         x: rect.x + 2,
-        y: rect.y - 1,
+        y: rect.y,
         width: rect.width - 2,
-        height: rect.height - 3
+        height: rect.height - 2
       })
     } else {
       this.d3Highlighter.classed('show', false)

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -293,10 +293,13 @@ class FlameGraph extends HtmlContent {
       this.applyRectToDiv(this.d3Highlighter, rect, true)
 
       this.d3HighlighterBox.classed('show', true)
-      this.applyRectToDiv(this.d3HighlighterBox, Object.assign({}, rect, {
-        // Align border with horizontal lines and tooltip edge
-        y: rect.y + 1
-      }))
+      this.applyRectToDiv(this.d3HighlighterBox, {
+        // Align border inside frame so it's visible against borders, heat etc
+        x: rect.x + 2,
+        y: rect.y - 1,
+        width: rect.width - 2,
+        height: rect.height - 3
+      })
     } else {
       this.d3Highlighter.classed('show', false)
       this.d3HighlighterBox.classed('show', false)

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -294,9 +294,9 @@ class FlameGraph extends HtmlContent {
       this.d3HighlighterBox.classed('show', true)
       this.applyRectToDiv(this.d3HighlighterBox, {
         // Align border inside frame so it's visible against borders, heat etc
-        x: rect.x + 2,
+        x: rect.x + Math.min(rect.width - 3, 2),
         y: rect.y,
-        width: rect.width - 2,
+        width: Math.max(rect.width - 2, 3),
         height: rect.height - 2
       })
     } else {

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -419,21 +419,24 @@ class FlameGraph extends HtmlContent {
       this.zoomFactorChanged = false
     }
 
+    if (toHide.size > 0 || toShow.size > 0) isChanged = true
+    if (isChanged || redrawGraph) {
+      // Clear the overlay canvas before it is redrawn
+      const overlay = this.d3CanvasOverlay.node()
+      const context = overlay.getContext('2d')
+      context.setTransform(1, 0, 0, 1, 0, 0)
+      context.clearRect(0, 0, overlay.width, overlay.height)
+    }
+
     // Must re-render tree before applying exclusions, else error if tree and exclusions change at same time
     if (redrawGraph) this.flameGraph.renderTree(this.renderedTree)
 
-    if (toHide.size > 0) {
-      toHide.forEach((name) => {
-        this.flameGraph.typeHide(name)
-      })
-      isChanged = true
-    }
-    if (toShow.size > 0) {
-      toShow.forEach((name) => {
-        this.flameGraph.typeShow(name)
-      })
-      isChanged = true
-    }
+    toHide.forEach((name) => {
+      this.flameGraph.typeHide(name)
+    })
+    toShow.forEach((name) => {
+      this.flameGraph.typeShow(name)
+    })
 
     if (isChanged || redrawGraph) this.updateMarkerBoxes()
   }

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -89,17 +89,7 @@ class FlameGraph extends HtmlContent {
 
     this.d3CanvasOverlay = this.d3Chart.append('canvas')
       .classed('flame-overlay', true)
-
-    const { width, height } = this.d3Chart.node().getBoundingClientRect()
-
-    this.d3CanvasOverlay.style('height', height + 'px')
-    this.d3CanvasOverlay.attr('height', height)
-    this.d3CanvasOverlay.style('width', width + 'px')
-    this.d3CanvasOverlay.attr('width', width)
-
-    this.overlayContext = this.d3CanvasOverlay.node().getContext('2d')
-    //  this.overlayContext.setTransform(1, 0, 0, 1, 0, 0)
-    this.overlayContext.scale(window.devicePixelRatio, window.devicePixelRatio)
+    this.resetOverlayContext()
 
     // creating the component to highlight the hovered node on the flame graph
     this.d3Highlighter = this.d3Element.append('div')
@@ -356,11 +346,28 @@ class FlameGraph extends HtmlContent {
     if (this.ui.zoomedNode) this.markNodeAsZoomed(this.ui.zoomedNode)
   }
 
+  resetOverlayContext () {
+    // Scales the context; and any change to <canvas> width/height attr resets the context content and properties
+    const height = this.flameGraph ? this.flameGraph.height() : this.d3Chart.node().getBoundingClientRect().height
+    const devicePixelRatio = window.devicePixelRatio
+
+    this.d3CanvasOverlay.style('height', height + 'px')
+    this.d3CanvasOverlay.style('width', this.width + 'px')
+
+    this.d3CanvasOverlay.attr('height', height * devicePixelRatio)
+    this.d3CanvasOverlay.attr('width', this.width * devicePixelRatio)
+
+    const context = this.d3CanvasOverlay.node().getContext('2d')
+    context.scale(window.devicePixelRatio, window.devicePixelRatio)
+    this.overlayContext = context
+  }
+
   clearOverlay () {
+    // Simply clear without rescaling or resetting other properties
     const overlay = this.d3CanvasOverlay.node()
-    const context = overlay.getContext('2d')
-    context.setTransform(1, 0, 0, 1, 0, 0)
-    context.clearRect(0, 0, overlay.width, overlay.height)
+    const devicePixelRatio = window.devicePixelRatio
+
+    this.overlayContext.clearRect(0, 0, overlay.width * devicePixelRatio, overlay.height * devicePixelRatio)
   }
 
   resize (zoomFactor = 0) {
@@ -398,12 +405,7 @@ class FlameGraph extends HtmlContent {
     if (this.sizeChanged) {
       this.flameGraph.cellHeight(this.cellHeight)
       this.flameGraph.minHeight(this.minHeight)
-      const height = this.flameGraph.height()
-      this.d3CanvasOverlay.style('height', height + 'px')
-      this.d3CanvasOverlay.attr('height', height)
-
-      this.d3CanvasOverlay.style('width', this.width + 'px')
-      this.d3CanvasOverlay.attr('width', this.width)
+      this.resetOverlayContext()
       // Order matters: setting overlay's width/height attrs wipes canvas, flameGraph.width() redraws it
       this.flameGraph.width(this.width)
 

--- a/visualizer/flame-graph.js
+++ b/visualizer/flame-graph.js
@@ -50,6 +50,8 @@ class FlameGraph extends HtmlContent {
       if (this.flameGraph) {
         if (cb) this.onNextAnimationEnd = cb
 
+        this.clearOverlay()
+
         this.isAnimating = true
         this.zoomedNodeData = node
 
@@ -266,6 +268,8 @@ class FlameGraph extends HtmlContent {
         this.onNextAnimationEnd()
         this.onNextAnimationEnd = null
       }
+
+      this.flameGraph.update()
     })
 
     // triggering the resize after the canvas rendered to take possible scrollbars into account
@@ -352,6 +356,13 @@ class FlameGraph extends HtmlContent {
     if (this.ui.zoomedNode) this.markNodeAsZoomed(this.ui.zoomedNode)
   }
 
+  clearOverlay () {
+    const overlay = this.d3CanvasOverlay.node()
+    const context = overlay.getContext('2d')
+    context.setTransform(1, 0, 0, 1, 0, 0)
+    context.clearRect(0, 0, overlay.width, overlay.height)
+  }
+
   resize (zoomFactor = 0) {
     this.zoomFactorChanged = this.zoomFactor !== zoomFactor
     this.zoomFactor = zoomFactor
@@ -420,13 +431,8 @@ class FlameGraph extends HtmlContent {
     }
 
     if (toHide.size > 0 || toShow.size > 0) isChanged = true
-    if (isChanged || redrawGraph) {
+    if (isChanged || redrawGraph) this.clearOverlay()
       // Clear the overlay canvas before it is redrawn
-      const overlay = this.d3CanvasOverlay.node()
-      const context = overlay.getContext('2d')
-      context.setTransform(1, 0, 0, 1, 0, 0)
-      context.clearRect(0, 0, overlay.width, overlay.height)
-    }
 
     // Must re-render tree before applying exclusions, else error if tree and exclusions change at same time
     if (redrawGraph) this.flameGraph.renderTree(this.renderedTree)

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -531,7 +531,6 @@ class Ui extends events.EventEmitter {
   }
 
   initializeElements () {
-
     // Cascades down tree in addContent() append/prepend order
     this.uiContainer.initializeElements()
   }


### PR DESCRIPTION
Needs this patch on d3-fg else there are small layout conflicts https://github.com/davidmarkclements/d3-fg/pull/30

This took a long time... I ran into a few dead ends and needed to start again with a completely new approach more than once, mostly around issues with sorting a D3 partition where you can have invisible intermediaries, and around the fact that we're displaying data that relates to more than one node, which runs into issues with the way the d3-fg canvas draws over itself. The best way I could find around these issues was to be not strict about the expected order of visible children, and to add another canvas overlay above the main canvas.

This PR outlines and labels code areas - one of the features in my original Flame design which seemed to work well in testing but wasn't necessary for launch, to help users navigate and relate the flamegraph to the flow of their application. 

Here's an example on a relatively simple flamegraph:

![image](https://user-images.githubusercontent.com/29628323/51826149-4491ca00-22de-11e9-8c00-739721c9e9ce.png)

https://upload.clinicjs.org/public/d375c1625f5d08e1a4a39f7b47a43d6ec487dab30d0f7972bd268f00d3860708/5759.clinic-flame.html

... where you can see very quickly that most of the activity is in Express, with almost no time in any other dependencies.

Here's an example with more dependencies, where you can see the transitions between modules - for example it's easier to identify the purpose of the stack that you can see goes from `restify` to `bunyan`, `mv`, `rimraf`, `glob`, then ends with operations in node core:

![image](https://user-images.githubusercontent.com/29628323/51826512-25476c80-22df-11e9-9a90-4f3af54d8c63.png)

https://upload.clinicjs.org/public/219ea937d670b63cd2c90a64cd3aa2a80aacde023a47e4f118f183e7f56f8114/5338.clinic-flame.html

There are also various small design tweaks in this PR to balance things, such as:

 - Making the frames slightly taller
 - Tweaks to the higlight and selection box so it's clearer what it is highlighting alongside lines and labels
- Simplifying the file names printed on the flamegraph slightly. Dependency labels that don't have space will drop the dependency name if it allows the rest of the path to be shown (e.g. `restify/lib/some-file.js` may truncate to `...lib/some-file.js` if there isn't full space since the dep name is already shown below)
