### PR TITLE
Filters/footer redesign

### DIFF
--- a/visualizer/common/button.js
+++ b/visualizer/common/button.js
@@ -1,7 +1,9 @@
-module.exports = ({ label, classNames = [], leftIcon = '', rightIcon = '', disabled = false, onClick } = {}) => {
+module.exports = ({ label, classNames = [], leftIcon = '', rightIcon = '', disabled = false, onClick, title } = {}) => {
   const button = document.createElement('button')
   button.classList.add('button', ...classNames)
+
   if (disabled) button.attr('disabled', true)
+  if (title) button.setAttribute('title', title)
 
   if (onClick) {
     button.addEventListener('click', onClick)

--- a/visualizer/filters-bar.css
+++ b/visualizer/filters-bar.css
@@ -25,8 +25,13 @@
   white-space: nowrap;
 }
 
+/* #filters-bar .center-col > .dropdown{
+  padding-bottom: 2px;
+} */
+
 #filters-bar .center-col > .checkbox {
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  border: 1px solid currentColor;
+  /* border-bottom-width: 2px;  */
 }
 
 #filters-bar .key-app {
@@ -35,11 +40,17 @@
 
 #filters-bar .key-deps {
   color: var(--area-color-deps);
+  background-color: var(--area-color-deps);
 }
 
 #filters-bar .key-core,
-#filters-bar .key-v8 {
+#filters-bar .key-v8,
+#filters-bar .key-v8 .dropdown-content-wrapper {
   color: var(--area-color-core);
+}
+
+#filters-bar .key-v8 {
+  background-color: var(--area-color-core);
 }
 
 #filters-bar .key-app .checkbox-copy-label:before,

--- a/visualizer/filters-bar.js
+++ b/visualizer/filters-bar.js
@@ -45,11 +45,10 @@ class FiltersContainer extends HtmlContent {
   initializeElements () {
     super.initializeElements()
 
-    this.d3Left.d3Element.append(() => dropdown({
+    this.d3Left.d3Element.append(() => button({
       classNames: ['after-bp-2'],
       label: 'Call stacks by duration. More info',
-      content: 'Some cool content here!',
-      expandAbove: true
+      rightIcon: circleQuestion
     }))
 
     this.d3Left.d3Element.append(() => button({

--- a/visualizer/filters-bar.js
+++ b/visualizer/filters-bar.js
@@ -52,6 +52,7 @@ class FiltersContainer extends HtmlContent {
     }))
 
     this.d3Left.d3Element.append(() => button({
+      title: 'Call stacks by duration. More info',
       classNames: ['before-bp-2'],
       leftIcon: circleQuestion
     }))
@@ -87,8 +88,8 @@ class FiltersContainer extends HtmlContent {
 
     // V8 combo ****
     this.d3V8Combo = this.d3Center.d3Element.append(() => dropdown({
+      classNames: ['key-v8'],
       label: checkbox({
-        classNames: ['key-v8'],
         leftLabel: 'V8',
         onChange: e => {
           this.setCodeAreaVisibility('all-v8', e.target.checked)

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -252,6 +252,7 @@ div#main-content {
   flex-grow: 1;
   flex-shrink: 1;
   overflow: auto;
+  overflow-x: hidden;
   position: relative;
 }
 


### PR DESCRIPTION
This PR brings a few note-worthing updates:
- The `filters` (a set of checkboxes) is now a self-contained component (`filters-content`)
- We now make use of the new base-components (`button`, `checkbox`, `drop-down`)
- We moved the Search-box and Options element from the top-right corner to the footer
- Search box is now responsive
- The new `side-bar` component replaces the previous `Options` drop-down (and it includes a responsive design)

Demo link:
https://upload.clinicjs.org/public/8c6b7c1a75d847ac5220c8da0cc42852669e684dc1bd28472091a9a1f33b39cd/5759.clinic-flame.html#selectedNode=933&zoomedNode=&exclude=83c0&merged=true


<img width="950" alt="screenshot 2019-02-20 at 16 35 17" src="https://user-images.githubusercontent.com/1298616/53103763-74736c80-352e-11e9-80cc-f7bbded32c35.png">
<img width="544" alt="screenshot 2019-02-20 at 16 36 01" src="https://user-images.githubusercontent.com/1298616/53103764-750c0300-352e-11e9-9e57-8cdfa572bbca.png">

