### PR TITLE
move rimraf to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "flame-gradient": "^1.0.0",
     "lodash.debounce": "^4.0.8",
     "pump": "^3.0.0",
-    "querystringify": "^2.1.0"
+    "querystringify": "^2.1.0",
+    "rimraf": "^2.6.3"
   },
   "devDependencies": {
     "chokidar": "^2.0.4",
-    "rimraf": "^2.6.2",
     "snazzy": "^8.0.0",
     "standard": "^12.0.1",
     "tap": "^12.0.0"


### PR DESCRIPTION
we use it in index.js.

(when using the Clinic CLI, it all works out, because rimraf is installed anyway. doing `npm install @nearform/flame` doesn't work though.)