### PR TITLE
Basic WebAssembly support

### DIFF
--- a/analysis/code-areas.js
+++ b/analysis/code-areas.js
@@ -36,6 +36,7 @@ function collectCodeAreas (trees) {
     { id: 'deps',
       children: toCodeAreaChildren(depCodeAreas),
       childrenVisibilityToggle: depCodeAreas.size > 2 },
+    { id: 'wasm' },
     { id: 'core' },
     { id: 'all-v8',
       children: [

--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -106,7 +106,8 @@ class FrameNode {
     const {
       category,
       type
-    } = this.getCoreOrV8Type(name, systemInfo) ||
+    } = this.getWasmType() ||
+      this.getCoreOrV8Type(name, systemInfo) ||
       this.getDepType(name, systemInfo) ||
       this.getAppType(name, appName)
 
@@ -133,6 +134,13 @@ class FrameNode {
     // TODO: add more cases like this
   }
 
+  getWasmType () {
+    if (this.isWasm) {
+      return { type: 'wasm', category: 'wasm' }
+    }
+    return null
+  }
+
   getCoreOrV8Type (name, systemInfo) {
     // TODO: see if any subdivisions of core are useful
     const core = { type: 'core', category: 'core' }
@@ -141,7 +149,7 @@ class FrameNode {
 
     if (/\[CODE:RegExp]$/.test(name)) {
       type = 'regexp'
-    } else if (!/\.m?js/.test(name) && !this.isWasm) {
+    } else if (!/\.m?js/.test(name)) {
       if (/\[CODE:.*?]$/.test(name) || /v8::internal::.*\[CPP]$/.test(name)) {
         type = 'v8'
       } else /* istanbul ignore next */ if (/\.$/.test(name)) {

--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -71,19 +71,22 @@ class FrameNode {
       this.functionName = isSharedLib ? '[SHARED_LIB]' : functionName
       this.fileName = isSharedLib ? functionName : null
       this.isInit = isInit != null
-    } else if ((m = this.name.match(wasmFrameRx))) {
-      const [
-        input, // eslint-disable-line no-unused-vars
-        functionName,
-        optimizationTag
-      ] = m
-      this.functionName = functionName
-      this.fileName = null
-      this.isOptimized = optimizationTag === 'Opt'
-      this.isUnoptimized = optimizationTag === 'Unopt'
-      this.isWasm = true
     } else {
-      throw new Error(`Encountered an unparseable frame "${this.name}"`)
+      /* istanbul ignore else: if none of the regexes we are missing a feature */
+      if ((m = this.name.match(wasmFrameRx))) {
+        const [
+          input, // eslint-disable-line no-unused-vars
+          functionName,
+          optimizationTag
+        ] = m
+        this.functionName = functionName
+        this.fileName = null
+        this.isOptimized = optimizationTag === 'Opt'
+        this.isUnoptimized = optimizationTag === 'Unopt'
+        this.isWasm = true
+      } else {
+        throw new Error(`Encountered an unparseable frame "${this.name}"`)
+      }
     }
   }
 

--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -1,6 +1,7 @@
 const path = require('path')
 
 const jsFrameRx = /^([~*])?((?:\S+?\(anonymous function\)|\S+)?(?: [a-zA-Z]+)*) (.*?):(\d+):(\d+)( \[INIT])?( \[INLINABLE])?$/
+const wasmFrameRx = /^(.*?) \[WASM:(\w+)]$/
 // This one has the /m flag because regexes may contain \n
 const cppFrameRx = /^(.*) (\[CPP]|\[SHARED_LIB]|\[CODE:\w+])( \[INIT])?$/m
 
@@ -24,6 +25,12 @@ class FrameNode {
     this.lineNumber = null
     this.columnNumber = null
 
+    this.isInit = false
+    this.isInlinable = false
+    this.isOptimized = false
+    this.isUnoptimized = false
+    this.isWasm = false
+
     // Don't try to identify anything for the root node
     if (fixedType) {
       this.category = 'none'
@@ -32,8 +39,8 @@ class FrameNode {
     }
 
     // C++ and v8 functions don't match, but they don't need to
-    const m = this.name.match(jsFrameRx)
-    if (m) {
+    let m
+    if ((m = this.name.match(jsFrameRx))) {
       const [
         input, // eslint-disable-line no-unused-vars
         optimizationFlag,
@@ -53,23 +60,30 @@ class FrameNode {
       this.isInlinable = isInlinable != null
       this.isOptimized = optimizationFlag === '~'
       this.isUnoptimized = optimizationFlag === '*'
+    } else if ((m = this.name.match(cppFrameRx))) {
+      const [
+        input, // eslint-disable-line no-unused-vars
+        functionName,
+        tag,
+        isInit
+      ] = m
+      const isSharedLib = tag === '[SHARED_LIB]'
+      this.functionName = isSharedLib ? '[SHARED_LIB]' : functionName
+      this.fileName = isSharedLib ? functionName : null
+      this.isInit = isInit != null
+    } else if ((m = this.name.match(wasmFrameRx))) {
+      const [
+        input, // eslint-disable-line no-unused-vars
+        functionName,
+        optimizationTag
+      ] = m
+      this.functionName = functionName
+      this.fileName = null
+      this.isOptimized = optimizationTag === 'Opt'
+      this.isUnoptimized = optimizationTag === 'Unopt'
+      this.isWasm = true
     } else {
-      const m = this.name.match(cppFrameRx)
-      /* istanbul ignore else: Only triggers if there's a bug */
-      if (m) {
-        const [
-          input, // eslint-disable-line no-unused-vars
-          functionName,
-          tag,
-          isInit
-        ] = m
-        const isSharedLib = tag === '[SHARED_LIB]'
-        this.functionName = isSharedLib ? '[SHARED_LIB]' : functionName
-        this.fileName = isSharedLib ? functionName : null
-        this.isInit = isInit != null
-      } else {
-        throw new Error(`Encountered an unparseable frame "${this.name}"`)
-      }
+      throw new Error(`Encountered an unparseable frame "${this.name}"`)
     }
   }
 
@@ -124,7 +138,7 @@ class FrameNode {
 
     if (/\[CODE:RegExp]$/.test(name)) {
       type = 'regexp'
-    } else if (!/\.m?js/.test(name)) {
+    } else if (!/\.m?js/.test(name) && !this.isWasm) {
       if (/\[CODE:.*?]$/.test(name) || /v8::internal::.*\[CPP]$/.test(name)) {
         type = 'v8'
       } else /* istanbul ignore next */ if (/\.$/.test(name)) {
@@ -236,6 +250,7 @@ class FrameNode {
       isUnoptimized: this.isUnoptimized,
       isInlinable: this.isInlinable,
       isInit: this.isInit,
+      isWasm: this.isWasm,
 
       value: this.onStack,
       onStackTop: this.onStackTop,

--- a/analysis/frame-node.js
+++ b/analysis/frame-node.js
@@ -29,7 +29,6 @@ class FrameNode {
     this.isInlinable = false
     this.isOptimized = false
     this.isUnoptimized = false
-    this.isWasm = false
 
     // Don't try to identify anything for the root node
     if (fixedType) {
@@ -83,7 +82,6 @@ class FrameNode {
         this.fileName = null
         this.isOptimized = optimizationTag === 'Opt'
         this.isUnoptimized = optimizationTag === 'Unopt'
-        this.isWasm = true
       } else {
         throw new Error(`Encountered an unparseable frame "${this.name}"`)
       }
@@ -106,7 +104,7 @@ class FrameNode {
     const {
       category,
       type
-    } = this.getWasmType() ||
+    } = this.getWasmType(name) ||
       this.getCoreOrV8Type(name, systemInfo) ||
       this.getDepType(name, systemInfo) ||
       this.getAppType(name, appName)
@@ -134,8 +132,8 @@ class FrameNode {
     // TODO: add more cases like this
   }
 
-  getWasmType () {
-    if (this.isWasm) {
+  getWasmType (name) {
+    if (/\[WASM:\w+]$/.test(name)) {
       return { type: 'wasm', category: 'wasm' }
     }
     return null

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "0x": "^4.7.2",
+    "0x": "^4.9.1",
     "@nearform/clinic-common": "nearform/node-clinic-common#feature/accordion",
     "copy-to-clipboard": "^3.0.8",
     "d3-array": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "chokidar": "^3.0.2",
+    "murmur3hash-wasm": "1.0.1",
     "snazzy": "^8.0.0",
     "standard": "^13.0.0",
     "tap": "^12.0.0"

--- a/test/analysis-categorise.test.js
+++ b/test/analysis-categorise.test.js
@@ -54,14 +54,14 @@ test('analysis - categorise node names', (t) => {
     isInlinable: true
   })
   t.match(byProps({ name: 'wasm-function[0] [WASM:Opt]' }, linux), {
-    category: 'app',
-    type: 'some-app',
+    category: 'wasm',
+    type: 'wasm',
     fileName: null,
     isOptimized: true
   })
   t.match(byProps({ name: 'ressa::Parser<CH>::parse_statement_list_item::ha21ba52d257287dd [WASM:Opt]' }, linux), {
-    category: 'app',
-    type: 'some-app',
+    category: 'wasm',
+    type: 'wasm',
     fileName: null,
     isOptimized: true
   })

--- a/test/analysis-categorise.test.js
+++ b/test/analysis-categorise.test.js
@@ -53,6 +53,18 @@ test('analysis - categorise node names', (t) => {
     isInit: false,
     isInlinable: true
   })
+  t.match(byProps({ name: 'wasm-function[0] [WASM:Opt]' }, linux), {
+    category: 'app',
+    type: 'some-app',
+    fileName: null,
+    isOptimized: true
+  })
+  t.match(byProps({ name: 'ressa::Parser<CH>::parse_statement_list_item::ha21ba52d257287dd [WASM:Opt]' }, linux), {
+    category: 'app',
+    type: 'some-app',
+    fileName: null,
+    isOptimized: true
+  })
 
   t.equal(byName('/usr/bin/node [SHARED_LIB]', linux), 'cpp')
   t.equal(byName('C:\\Program Files\\nodejs\\node.exe [SHARED_LIB]', windows), 'cpp')

--- a/test/fixtures/wasm.js
+++ b/test/fixtures/wasm.js
@@ -1,0 +1,8 @@
+var f = require('murmur3hash-wasm')
+var tenKb = require('crypto').randomBytes(10 * 1024)
+var start = Date.now()
+var result = 0
+while (Date.now() < start + 1000) {
+  result ^= f(tenKb, Math.floor(Math.random() * (1 << 31)))
+}
+console.log(result)

--- a/visualizer/filters-bar.css
+++ b/visualizer/filters-bar.css
@@ -53,6 +53,7 @@
 }
 
 #filters-bar .key-core,
+#filters-bar .key-wasm,
 #filters-bar .key-v8,
 #filters-bar .key-v8 .dropdown-content-wrapper {
   color: var(--area-color-core);
@@ -61,7 +62,8 @@
 
 #filters-bar .key-app .checkbox-copy-label:before,
 #filters-bar .key-deps .checkbox-copy-label:before,
-#filters-bar .key-core .checkbox-copy-label:before {
+#filters-bar .key-core .checkbox-copy-label:before,
+#filters-bar .key-wasm .checkbox-copy-label:before {
   content: '';
   width: 1em;
   height: 1em;
@@ -74,7 +76,8 @@
 @media screen and (min-width: 630px) {
   #filters-bar .key-app .checkbox-copy-label:before,
   #filters-bar .key-deps .checkbox-copy-label:before,
-  #filters-bar .key-core .checkbox-copy-label:before {
+  #filters-bar .key-core .checkbox-copy-label:before,
+  #filters-bar .key-wasm .checkbox-copy-label:before {
     display: inline-flex;
   }
 }

--- a/visualizer/filters-bar.js
+++ b/visualizer/filters-bar.js
@@ -152,12 +152,16 @@ class FiltersContainer extends HtmlContent {
           .find(
             data => data.excludeKey === key
           )
-        this.ui.setCodeAreaVisibility({
-          codeArea: area,
-          visible: checked
-        })
-        this.ui.updateExclusions()
-        this.ui.draw()
+        if (area) {
+          this.ui.setCodeAreaVisibility({
+            codeArea: area,
+            visible: checked
+          })
+          this.ui.updateExclusions()
+          this.ui.draw()
+        } else {
+          console.error('Could not find code area for', key, 'in', this.ui)
+        }
         parent.classList.remove('pulsing')
       }
       , 15)

--- a/visualizer/filters-bar.js
+++ b/visualizer/filters-bar.js
@@ -73,6 +73,20 @@ class FiltersContainer extends HtmlContent {
     })
     this.d3DepsCombo = this.d3Center.d3Element.append(() => this.depsDropDown)
 
+    // TODO maybe disable if there are no wasm frames?
+    this.d3WasmCheckBox = this.d3Center.d3Element.append('div')
+      .classed('filter-option', true)
+      .classed('key-wasm', true)
+      .append('div')
+      .classed('label-wrapper', true)
+      .append(() =>
+        checkbox({
+          leftLabel: `<span class='after-bp-1'>WebAssembly</span>
+            <span class='before-bp-1'>WASM</span>`,
+          onChange: e => this.setCodeAreaVisibility('wasm', e.target)
+        })
+      )
+
     // NodeJS checkbox ****
     this.d3NodeCheckBox = this.d3Center.d3Element.append('div')
       .classed('filter-option', true)
@@ -169,6 +183,9 @@ class FiltersContainer extends HtmlContent {
         </span>
         <span class='before-bp-2'>App</span>
       `)
+
+    this.d3WasmCheckBox.select('input').node()
+      .checked = !this.ui.dataTree.exclude.has('wasm')
 
     // node js
     this.d3NodeCheckBox.select('input').node()

--- a/visualizer/flame-graph-label.js
+++ b/visualizer/flame-graph-label.js
@@ -54,7 +54,7 @@ function renderFrameLabel (frameHeight, options) {
   if (fileName === null) {
     if (nodeData.type === 'v8') fileName = 'Compiled V8 C++'
     if (nodeData.type === 'cpp') fileName = 'Compiled C++'
-    if (nodeData.isWasm) fileName = 'Compiled WebAssembly'
+    if (nodeData.type === 'wasm') fileName = 'Compiled WebAssembly'
   }
   if (nodeData.category === 'deps') fileName = fileName.replace(/\.\.?[\\/]node_modules[\\/]/, '')
 

--- a/visualizer/flame-graph-label.js
+++ b/visualizer/flame-graph-label.js
@@ -54,6 +54,7 @@ function renderFrameLabel (frameHeight, options) {
   if (fileName === null) {
     if (nodeData.type === 'v8') fileName = 'Compiled V8 C++'
     if (nodeData.type === 'cpp') fileName = 'Compiled C++'
+    if (nodeData.isWasm) fileName = 'Compiled WebAssembly'
   }
   if (nodeData.category === 'deps') fileName = fileName.replace(/\.\.?[\\/]node_modules[\\/]/, '')
 

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -396,6 +396,7 @@ class Ui extends events.EventEmitter {
       app: this.dataTree.appName || 'profiled application',
       deps: singular ? 'Dependency' : 'Dependencies',
       core: 'Node JS',
+      wasm: 'WebAssembly',
 
       'is:inlinable': 'Inlinable',
       'is:init': 'Init',
@@ -425,6 +426,7 @@ class Ui extends events.EventEmitter {
       app: `<span>Functions in the code of the application being profiled.</span>`,
       deps: `<span>External modules in the application's node_modules directory.</span>`,
       core: `<span>JS functions in core Node.js APIs.</span>`,
+      wasm: `<span>Compiled WebAssembly code.</span>`,
       'all-v8': `<span>The JavaScript engine used by default in Node.js.</span> ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-v8')}`,
       'all-v8:v8': `<span>Operations in V8's implementation of JS.</span> ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-v8-runtime')}`,
       'all-v8:native': `<span>JS compiled into V8, such as prototype methods and eval.</span> ${this.createMoreInfoLink('https://clinicjs.org/documentation/flame/09-advanced-controls/#controls-v8-native')}`,
@@ -561,6 +563,7 @@ class Ui extends events.EventEmitter {
       app: computedStyle.getPropertyValue('--area-color-app').trim(),
       deps: computedStyle.getPropertyValue('--area-color-deps').trim(),
       core: computedStyle.getPropertyValue('--area-color-core').trim(),
+      wasm: computedStyle.getPropertyValue('--area-color-core').trim(),
       'all-v8': computedStyle.getPropertyValue('--area-color-core').trim(),
 
       'opposite-contrast': computedStyle.getPropertyValue('--opposite-contrast').trim(),


### PR DESCRIPTION
Depends on https://github.com/davidmarkclements/0x/pull/218

Example: https://upload.clinicjs.org/public/9f949dda1c7a611cc6cb4a270e7793dc75d205c508605b761b88fd91000e9f16/463707.clinic-flame.html#selectedNode=678&zoomedNode=678&exclude=8fff-ef00&merged=true
Code used for example: test suite from https://github.com/goto-bus-stop/require-detective

This fixes a crash on WebAssembly stack frames. WASM frames are now treated as a separate category, next to App/Deps/Core/V8.
One thing that may be worth a shot in the future is to categorise wasm and eval frames based on their parent frame. If the parent is in a dependency, the wasm is likely part of that dependency (most<sup>[citation needed]</sup> wasm modules ship with a commonjs wrapper in the same npm package anyways). A possible argument against that is that compiled wasm may have stripped symbols and wasm-function[342] is not a very helpful label.