### PR TITLE
Display flame version beneath logo

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ class ClinicFlame extends events.EventEmitter {
     const nearFormLogoFile = fs.createReadStream(nearFormLogoPath)
     const clinicFaviconBase64 = fs.createReadStream(clinicFaviconPath)
 
-    data.flameVersion = require('./package.json').version
+    const flameVersion = require('./package.json').version
 
     // build JS
     const scriptFile = buildJs({
@@ -147,6 +147,7 @@ class ClinicFlame extends events.EventEmitter {
       headerLogoTitle: 'Clinic Flame on Clinicjs.org',
       headerLogo: logoFile,
       headerText: 'Flame',
+      toolVersion: flameVersion,
       nearFormLogo: nearFormLogoFile,
       uploadId: outputFilename.split('/').pop().split('.html').shift(),
       body: '<main></main>'

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ const pump = require('pump')
 const buildJs = require('@nearform/clinic-common/scripts/build-js')
 const buildCss = require('@nearform/clinic-common/scripts/build-css')
 const mainTemplate = require('@nearform/clinic-common/templates/main')
-const semver = require('semver')
 
 class ClinicFlame extends events.EventEmitter {
   constructor (settings = {}) {
@@ -116,7 +115,6 @@ class ClinicFlame extends events.EventEmitter {
     const clinicFaviconBase64 = fs.createReadStream(clinicFaviconPath)
 
     data.flameVersion = require('./package.json').version
-    data.nodeVersion = semver.parse(process.version).version
 
     // build JS
     const scriptFile = buildJs({

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const pump = require('pump')
 const buildJs = require('@nearform/clinic-common/scripts/build-js')
 const buildCss = require('@nearform/clinic-common/scripts/build-css')
 const mainTemplate = require('@nearform/clinic-common/templates/main')
+const semver = require('semver')
 
 class ClinicFlame extends events.EventEmitter {
   constructor (settings = {}) {
@@ -113,6 +114,9 @@ class ClinicFlame extends events.EventEmitter {
     const logoFile = fs.createReadStream(logoPath)
     const nearFormLogoFile = fs.createReadStream(nearFormLogoPath)
     const clinicFaviconBase64 = fs.createReadStream(clinicFaviconPath)
+
+    data.flameVersion = require('./package.json').version
+    data.nodeVersion = semver.parse(process.version).version
 
     // build JS
     const scriptFile = buildJs({

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "0x": "^4.9.1",
-    "@nearform/clinic-common": "^2.2.0",
+    "@nearform/clinic-common": "^3.0.0",
     "copy-to-clipboard": "^3.0.8",
     "d3-array": "^2.0.2",
     "d3-fg": "^6.13.1",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "lodash.debounce": "^4.0.8",
     "pump": "^3.0.0",
     "querystringify": "^2.1.0",
-    "rimraf": "^3.0.2",
-    "semver": "^7.3.2"
+    "rimraf": "^3.0.2"
   },
   "devDependencies": {
     "chokidar": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "lodash.debounce": "^4.0.8",
     "pump": "^3.0.0",
     "querystringify": "^2.1.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "semver": "^7.3.2"
   },
   "devDependencies": {
     "chokidar": "^3.0.2",


### PR DESCRIPTION
Pass the tool version to the html template.

<img width="487" alt="Screenshot 2020-04-30 at 16 20 24" src="https://user-images.githubusercontent.com/43864112/80728262-a7d06480-8afe-11ea-913e-03197d92e54e.png">

[Issue FK02](https://trello.com/c/vgIgBXME/843-fk02-visibility-of-system-status)