### PR TITLE
Move Help button to top right

### DIFF
--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -630,7 +630,7 @@ class Ui extends events.EventEmitter {
       title: 'Click to start the step-by-step UI features guide!'
     })
     // Place help button top right
-    d3.select('body').select('.nc-header__inner').append(() => this.helpButton.button)
+    d3.select('.nc-header__inner').append(() => this.helpButton.button)
 
     this.flameWrapperSpinner = spinner.attachTo(document.querySelector('#flame-main'))
   }

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -629,7 +629,8 @@ class Ui extends events.EventEmitter {
       label: '<span class="before-bp-1">Guide</span><span class="after-bp-1">Show how to use this</span>',
       title: 'Click to start the step-by-step UI features guide!'
     })
-    this.footer.d3Element.select('#filters-bar .left-col').append(() => this.helpButton.button)
+    // Place help button top right
+    d3.select('body').select('.nc-header__inner').append(() => this.helpButton.button)
 
     this.flameWrapperSpinner = spinner.attachTo(document.querySelector('#flame-main'))
   }


### PR DESCRIPTION
Issue:
"Bottom left corner is not the most common place for help. Top right corner is more frequent."

Fix:
Moved to top right. Some styling of the button will also be required.

![image](https://user-images.githubusercontent.com/4488048/80726664-9e45fd00-8afc-11ea-9a2f-006cef328313.png)
