### PR TITLE
Put Nearform logo in bottom left

### DIFF
--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -8,7 +8,8 @@ const debounce = require('lodash.debounce')
 const DataTree = require('./data-tree.js')
 const History = require('./history.js')
 const spinner = require('@nearform/clinic-common/spinner')
-const logo = require(path.join(__dirname, 'nearform-logo.svg'))
+const fs = require('fs')
+const logo = fs.readFileSync(path.join(__dirname, 'nearform-logo.svg'), 'utf8')
 
 const close = require('@nearform/clinic-common/icons/close')
 

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const d3 = require('./d3.js')
 const path = require('path')
 const events = require('events')
 const htmlContentTypes = require('./html-content-types.js')
@@ -649,8 +650,9 @@ class Ui extends events.EventEmitter {
 
   createLogoLink () {
     const el = document.createElement('div')
-    el.innerHTML = `<a class="nc-header__sponsor" href="https://nearform.com"
-      title="NearForm" target="_blank" rel="noopener noreferrer">${logo}</a>`.trim()
+    d3.select(el).append('a').classed('nc-header__sponsor', true).attr('href', 'https://nearform.com').attr('title', 'NearForm').attr('target', '_blank').attr('rel', 'noopener noreferrer')
+      .enter()
+      .append(logo)
     return el.firstChild
   }
 

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -633,7 +633,7 @@ class Ui extends events.EventEmitter {
       label: '<span class="before-bp-1">Guide</span><span class="after-bp-1">Show how to use this</span>',
       title: 'Click to start the step-by-step UI features guide!'
     })
-    this.footer.d3Element.select('#filters-bar .left-col').append(() => this.createLogoLink())
+    this.footer.d3Element.select('#filters-bar .left-col').append(() => this.createLogoLink().node())
 
     this.flameWrapperSpinner = spinner.attachTo(document.querySelector('#flame-main'))
   }
@@ -652,16 +652,15 @@ class Ui extends events.EventEmitter {
   createLogoLink () {
     const el = d3.create('div').attr('id', 'nearform_logo')
 
-    let newel = el.append('a')
+    el.append('a')
       .classed('nc-header__sponsor', true)
       .attr('href', 'https://nearform.com')
       .attr('title', 'NearForm')
       .attr('target', '_blank')
       .attr('rel', 'noopener noreferrer')
-      
-    newel.selectAll('a').enter().append(logo)
+      .html(logo)
 
-    return newel
+    return el
   }
 
   createMoreInfoLink (href) {

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -650,11 +650,18 @@ class Ui extends events.EventEmitter {
   }
 
   createLogoLink () {
-    const el = document.createElement('div')
-    d3.select(el).append('a').classed('nc-header__sponsor', true).attr('href', 'https://nearform.com').attr('title', 'NearForm').attr('target', '_blank').attr('rel', 'noopener noreferrer')
-      .enter()
-      .append(logo)
-    return el.firstChild
+    const el = d3.create('div').attr('id', 'nearform_logo')
+
+    let newel = el.append('a')
+      .classed('nc-header__sponsor', true)
+      .attr('href', 'https://nearform.com')
+      .attr('title', 'NearForm')
+      .attr('target', '_blank')
+      .attr('rel', 'noopener noreferrer')
+      
+    newel.selectAll('a').enter().append(logo)
+
+    return newel
   }
 
   createMoreInfoLink (href) {

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -7,6 +7,7 @@ const debounce = require('lodash.debounce')
 const DataTree = require('./data-tree.js')
 const History = require('./history.js')
 const spinner = require('@nearform/clinic-common/spinner')
+const logo = require(path.join(__dirname, 'nearform-logo.svg'))
 
 const close = require('@nearform/clinic-common/icons/close')
 
@@ -647,17 +648,10 @@ class Ui extends events.EventEmitter {
   }
 
   createLogoLink () {
-    const logo = path.join(__dirname, 'visualizer', 'nearform-logo.svg')
-    return `<a
-      class="nc-header__logo"
-      href="https://github.com/nearform/node-clinic-flame"
-      title="Clinic Flame on GitHub"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      ${logo}
-      <span class="nc-header__logo-text">Flame</span>
-    </a>`
+    const el = document.createElement('div')
+    el.innerHTML = `<a class="nc-header__sponsor" href="https://nearform.com"
+      title="NearForm" target="_blank" rel="noopener noreferrer">${logo}</a>`.trim()
+    return el.firstChild
   }
 
   createMoreInfoLink (href) {

--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const path = require('path')
 const events = require('events')
 const htmlContentTypes = require('./html-content-types.js')
 const debounce = require('lodash.debounce')
@@ -629,7 +630,7 @@ class Ui extends events.EventEmitter {
       label: '<span class="before-bp-1">Guide</span><span class="after-bp-1">Show how to use this</span>',
       title: 'Click to start the step-by-step UI features guide!'
     })
-    this.footer.d3Element.select('#filters-bar .left-col').append(() => this.helpButton.button)
+    this.footer.d3Element.select('#filters-bar .left-col').append(() => this.createLogoLink())
 
     this.flameWrapperSpinner = spinner.attachTo(document.querySelector('#flame-main'))
   }
@@ -643,6 +644,20 @@ class Ui extends events.EventEmitter {
 
     // setting Presentation Mode
     this.setPresentationMode(this.presentationMode)
+  }
+
+  createLogoLink () {
+    const logo = path.join(__dirname, 'visualizer', 'nearform-logo.svg')
+    return `<a
+      class="nc-header__logo"
+      href="https://github.com/nearform/node-clinic-flame"
+      title="Clinic Flame on GitHub"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      ${logo}
+      <span class="nc-header__logo-text">Flame</span>
+    </a>`
   }
 
   createMoreInfoLink (href) {


### PR DESCRIPTION
Issue:
Eyes are drawn to the NearForm logo although it is a secondary element in terms of hierarchy.

Fix:
1. Remove the Nearform logo from the header. https://github.com/nearform/node-clinic-common/pull/24 (Merged)
2. This PR will put the logo in the bottom left. Since https://github.com/nearform/node-clinic-flame/pull/115 created the space required. (Merged)

![image](https://user-images.githubusercontent.com/4488048/81944465-b6d20f00-95f4-11ea-9e2a-a641f110cd67.png)

~~Recommended to merge https://github.com/nearform/node-clinic-flame/pull/115 before this one.~~ (Merged)

Position of logo will be adjusted via:
https://github.com/nearform/node-clinic-common/pull/29