### PR TITLE
Tweak colour of core label to lighter grey

### DIFF
--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -70,7 +70,7 @@ html {
 
   --area-color-app: var(--max-contrast);
   --area-color-deps: rgb(63, 125, 198);
-  --area-color-core: rgb(156, 170, 159);
+  --area-color-core: rgb(230, 230, 230);
 
   /* scrollbars */
   --scrollbar-primary-color-val: 145, 169, 179;


### PR DESCRIPTION
Issue:
"Gray text on black background unreadable."

Fix:
Keep grey colour to differ from app label (white) but make it lighter to increase contrast.

Before:
![image](https://user-images.githubusercontent.com/4488048/81161535-9ca88900-8f83-11ea-8ab0-5b50d181ea2d.png)

After:
![image](https://user-images.githubusercontent.com/4488048/81161566-a8944b00-8f83-11ea-8df4-c47abdb4240e.png)
