### PR TITLE
Change dark shadow into a light shadow for improved contrast

### DIFF
--- a/visualizer/flame-graph.css
+++ b/visualizer/flame-graph.css
@@ -108,7 +108,7 @@ chart > div {
   position: absolute;
   pointer-events: none;
   border-top: 3px solid var(--main-bg-color);
-  background: linear-gradient(to bottom, rgba(var(--opposite-color-val), 0.8), rgba(var(--opposite-color-val), 0));
+  background: linear-gradient(to bottom, rgba(var(--grey-highlight-color-val), 0.3), rgba(var(--grey-highlight-color-val), 0));
 }
 
 .fg-tooltip-actions {


### PR DESCRIPTION
Issue:
"Shadow makes content below unreadable."

Fix:
Keep the linear gradient but make it light coloured to improve text contrast. 

Before:
![image](https://user-images.githubusercontent.com/4488048/81183308-e787c800-8fa6-11ea-9d0f-6d453b1b1c64.png)

After:
![image](https://user-images.githubusercontent.com/4488048/81183108-a5f71d00-8fa6-11ea-9caa-611f0645fbc1.png)
