### PR TITLE
Improve contrast of graph label text

### DIFF
--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -69,7 +69,7 @@ html {
   --checkbox-border-color: rgba(var(--grey-highlight-color-val), 0.9);
 
   --area-color-app: var(--max-contrast);
-  --area-color-deps: rgb(63, 125, 198);
+  --area-color-deps: rgb(255, 170, 43);
   --area-color-core: rgb(230, 230, 230);
 
   /* scrollbars */
@@ -134,7 +134,7 @@ html.presentation-mode {
   --grey-highlight: rgb(255, 255, 255);
   --primary-grey: rgb(var(--grey-highlight-color-val));
 
-  --area-color-deps: rgb(145, 210, 255);
+  --area-color-deps: rgb(255, 170, 43);
   --area-color-core: rgb(160, 155, 215);
 
   --clickable-bg-hover : rgb(0, 0, 0);


### PR DESCRIPTION
Issue:
"Blue text on black is not readable."

Fix:
Change blue to "flame orange". This improves the text readability and also matches in with the app colour scheme.

Before:
![image](https://user-images.githubusercontent.com/4488048/81418731-0de36a00-9145-11ea-8a17-af65595de362.png)

After:
![image](https://user-images.githubusercontent.com/4488048/81418609-d5439080-9144-11ea-870b-b8445d96d061.png)
 