### PR TITLE
Change copied-to-clipboard message colour

### DIFF
--- a/visualizer/message.css
+++ b/visualizer/message.css
@@ -15,11 +15,11 @@
   margin: 1px 0px;
   font-size: var(--small-text-size);
   text-align: center;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgb(51, 51, 51);
 }
 
 #message-component pre {
-  color: rgba(255, 255, 255, 0.9);
+  color: rgb(51, 51, 51);
   font-style: italic;
   margin: 1em 1em 0.5em;
   word-break: break-word;

--- a/visualizer/message.css
+++ b/visualizer/message.css
@@ -7,7 +7,7 @@
 }
 
 #message-component .message-text {
-  background-color: rgb(145, 210, 255);
+  background-color: rgb(255, 170, 43);
   box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.3);
   color: '#fff';
   padding: 5px;

--- a/visualizer/message.css
+++ b/visualizer/message.css
@@ -7,7 +7,7 @@
 }
 
 #message-component .message-text {
-  background-color: rgb(5, 97, 47);
+  background-color: rgb(145, 210, 255);
   box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.3);
   color: '#fff';
   padding: 5px;


### PR DESCRIPTION
Changed the colour from green to flame logo orange to make the colour scheme more consistent

Before:
<img width="762" alt="Screenshot 2020-05-11 at 14 42 50" src="https://user-images.githubusercontent.com/43864112/81568465-bbe55300-9395-11ea-86b0-57072881627b.png">

After:
<img width="762" alt="Screenshot 2020-05-11 at 14 40 54" src="https://user-images.githubusercontent.com/43864112/81568490-c3a4f780-9395-11ea-871a-ad0cc0b1ac36.png">


[Issue FD02](https://trello.com/c/18XBhckv/831-fd02-consistency-and-standards)