### PR TITLE
add d3-selection module loading

### DIFF
--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -15,6 +15,8 @@ const getNoDataNode = require('./no-data-node.js')
 const { button, walkthroughButton } = require('@nearform/clinic-common/base/index.js')
 const wtSteps = require('./walkthrough-steps.js')
 
+const d3 = require('d3-selection')
+
 class Ui extends events.EventEmitter {
   constructor (wrapperSelector) {
     super()


### PR DESCRIPTION
`npm run test` was failing at line 635 `d3.select('.nc-header...`