### PR TITLE
Enabling optimization status doesn't make any sense on merged tree

### DIFF
--- a/visualizer/filters-content.css
+++ b/visualizer/filters-content.css
@@ -102,6 +102,6 @@
   white-space: normal;
 }
 
-.filters-content .options #option-showoptimizationstatus .disabled {
+.filters-content .options #option-showoptimizationstatus.disabled {
   opacity: 0.5
 }

--- a/visualizer/filters-content.css
+++ b/visualizer/filters-content.css
@@ -102,4 +102,6 @@
   white-space: normal;
 }
 
-
+.filters-content .options #option-showoptimizationstatus .disabled {
+  opacity: 0.5
+}

--- a/visualizer/filters-content.js
+++ b/visualizer/filters-content.js
@@ -307,6 +307,11 @@ class FiltersContent extends HtmlContent {
       ul.innerHTML = ''
       ul.appendChild(this._createListItems(this.sections.advanced))
 
+      // "Show optimization status" disabled class by default
+      const showOptStatusId = this.sections.advanced[this.sections.advanced.length-1].id
+      const el = this.d3Advanced.select('#'+showOptStatusId)
+      el.classed('disabled', true)
+
       // Preferences
       ul = this.d3Preferences.select('ul').node()
       ul.innerHTML = ''

--- a/visualizer/filters-content.js
+++ b/visualizer/filters-content.js
@@ -134,12 +134,10 @@ class FiltersContent extends HtmlContent {
           checked: useMerged,
           onChange: (datum, event) => {
             this.ui.setUseMergedTree(event.target.checked)
-            // Toggle "Show optimization status" disabled class if Merged enabled
-            if(event.target.checked) {
-              const showOptStatusId = this.sections.advanced[this.sections.advanced.length-1].id
-              const el = this.d3Advanced.select('#'+showOptStatusId)
-              el.classed('disabled', true)
-            }
+            // Toggle "Show optimization status" disabled class if Merged enabled/disabled
+            const showOptStatusId = this.sections.advanced[this.sections.advanced.length-1].id
+            const el = this.d3Advanced.select('#'+showOptStatusId)
+            el.classed('disabled', event.target.checked)
           }
         },
         {

--- a/visualizer/filters-content.js
+++ b/visualizer/filters-content.js
@@ -270,6 +270,7 @@ class FiltersContent extends HtmlContent {
 
     div.appendChild(checkbox({
       checked: data.checked,
+      disabled: data.disabled,
       indeterminate: data.indeterminate,
       rightLabel: `
         <span class="name">${data.label}</span>

--- a/visualizer/filters-content.js
+++ b/visualizer/filters-content.js
@@ -134,6 +134,12 @@ class FiltersContent extends HtmlContent {
           checked: useMerged,
           onChange: (datum, event) => {
             this.ui.setUseMergedTree(event.target.checked)
+            // Toggle "Show optimization status" disabled class if Merged enabled
+            if(event.target.checked) {
+              const showOptStatusId = this.sections.advanced[this.sections.advanced.length-1].id
+              const el = this.d3Advanced.select('#'+showOptStatusId)
+              el.classed('disabled', true)
+            }
           }
         },
         {
@@ -266,7 +272,7 @@ class FiltersContent extends HtmlContent {
   }
 
   _createOptionElement (data) {
-    const div = helpers.toHtml(`<div class="${data.excludeKey ? data.excludeKey.split(':')[0] : ''}"></div>`)
+    const div = helpers.toHtml(`<div id="${data.id ? data.id : ''}" class="${data.excludeKey ? data.excludeKey.split(':')[0] : ''}"></div>`)
 
     div.appendChild(checkbox({
       checked: data.checked,


### PR DESCRIPTION
Currently you can still toggle "Show optimization status" even if "Merge" option is checked. The UI should reflect that these options cannot be used together.

![image](https://user-images.githubusercontent.com/4488048/82224612-f746cb00-991b-11ea-98af-c1bcd6961989.png)

The checkbox for "Show optimization status" will be disabled if "Merge" option is checked. Also may look to:

- Improve disabled style.
- Provide a tooltip to describe why the option is disabled.