### PR TITLE
add additional info to walkthrough

### DIFF
--- a/visualizer/walkthrough-steps.js
+++ b/visualizer/walkthrough-steps.js
@@ -19,6 +19,7 @@ const WalkthroughSteps = [
       </h4>
       <p>This is a Flamegraph. Each block represents the time spent executing calls to a function. The wider the block, the more time was spent.</p>
       <p>Blocks sit on the function that called them, so the stack below each block shows its stack trace.</p>
+      <p>Double clicking on a block will expand it and its children.</p>
     </div>
     `
   },


### PR DESCRIPTION
Add a bit of information letting the user know about the double click to expand function on function blocks.

[Relates to FB02](https://trello.com/c/06IWR6Jo/822-fb02-flexibility-and-efficiency-of-use)

[Additional issue on Trello this relates to](https://trello.com/c/8iYqGeYa/724-new-tooltip-menu-make-double-clicking-into-a-frame-more-intuitive)

https://github.com/nearform/node-clinic-flame/issues/86