### PR TITLE
Remove toggle of presentation mode class

### DIFF
--- a/visualizer/ui.js
+++ b/visualizer/ui.js
@@ -207,9 +207,6 @@ class Ui extends events.EventEmitter {
 
   setPresentationMode (mode) {
     this.presentationMode = mode
-    // switching the class on the html element
-    document.documentElement.classList.toggle('presentation-mode', mode)
-    this.setExposedCSS()
     this.emit('presentationMode', mode)
   }
 


### PR DESCRIPTION
Issue:
"Unclear what making the background brighter helps with. Either use a light theme or a dark one."

Fix:
Remove the strange colour changes on Presentation Mode. Keep the UI scaling feature as this seems to be the concept behind the mode.

![image](https://user-images.githubusercontent.com/4488048/82665843-827dd480-9c2c-11ea-8f60-1d4ca3ca61c4.png)
