### PR TITLE
Add node 14 to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [10.12.0, 10.x, 12.x, 13.x]
+        node-version: [10.12.0, 10.x, 12.x, 13.x, 14.x]
 
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
Well, this is a simple one but I think it's worth adding node 14 to the GitHub ci workflow.

I've tested it locally and all tests are green.